### PR TITLE
[AAP-5846] Add option to configure Kafka offset reset method

### DIFF
--- a/benthomasson/eda/plugins/event_source/kafka.py
+++ b/benthomasson/eda/plugins/event_source/kafka.py
@@ -8,6 +8,8 @@ Arguments:
     port:      The port where the kafka server is listening
     topic:     The kafka topic
     group_id:  A kafka group id
+    offset:    Where to automatically reset the offset. [latest, earliest]
+               Default to latest
 
 
 
@@ -27,6 +29,11 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
     host = args.get("host")
     port = args.get("port")
     group_id = args.get("group_id", None)
+    offset = args.get("offset", "latest")
+ 
+    if offset not in ("latest", "earliest"):
+        logger.error("Invalid offset option: %s. Use default latest", offset)
+        offset = "latest"
 
     kafka_consumer = AIOKafkaConsumer(
         topic,
@@ -34,7 +41,7 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
         group_id=group_id,
         enable_auto_commit=True,
         max_poll_records=1,
-        auto_offset_reset="earliest",
+        auto_offset_reset=offset,
     )
     await kafka_consumer.start()
 


### PR DESCRIPTION
Accept option offset=latest or earliest. Default to latest.

Resolves AAP-5846: Allow to configure Kafka offset reset option