### PR TITLE
Fix failing workflows due to missing test requirements

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: install test requirements
         run: |
           export GITHUB_TOKEN=$EDA_TOKEN
-          pip install -r test_requirements.txt
+          pip install -r requirements.txt -r test_requirements.txt
         working-directory: benthomasson/eda
 
       - name: install collection


### PR DESCRIPTION
Add requirements.txt to workflow pip install since some tests, such as webhook integration test, fail due to missing dependencies.