### PR TITLE
[AAP-6385] fix ansible dependencies for install-rulebook role

### DIFF
--- a/roles/install_ansible_rulebook/tasks/install_fedora.yml
+++ b/roles/install_ansible_rulebook/tasks/install_fedora.yml
@@ -32,15 +32,15 @@
   ansible.builtin.pip:
     name:
       - pip
+      - wheel
     state: latest
 
-- name: Install pip dependencies
+- name: Ensure ansible dependencies
   ansible.builtin.pip:
     name:
       - ansible
       - ansible-runner
-      - wheel
-    state: latest
+    state: present
 
 - name: install ansible-rulebook
   environment:

--- a/roles/install_ansible_rulebook/tasks/install_macosx.yml
+++ b/roles/install_ansible_rulebook/tasks/install_macosx.yml
@@ -37,15 +37,15 @@
   ansible.builtin.pip:
     name:
       - pip
+      - wheel
     state: latest
 
-- name: Install pip dependencies
+- name: Ensure ansible dependencies
   ansible.builtin.pip:
     name:
       - ansible
       - ansible-runner
-      - wheel
-    state: latest
+    state: present
 
 - name: install ansible-rulebook
   environment:


### PR DESCRIPTION
Fixes AAP-6385
Ansible and ansible-runner are indirect dependencies and must be managed in the system regardless of ansible-rulebook. The playbook started to install them by convenience. But since can be installed in a system scope, the playbook can fail trying to update them, so to avoid errors, better to move as "present" if those packages were previously installed by the user. 