### PR TITLE
replace Unicode quotes and remove end-of-line whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ INFO:aiohttp.access:127.0.0.1 [14/Oct/2022:09:49:32 +0000] "POST /endpoint HTTP/
 INFO:root:Waiting for event
 ```
 
-But once our payload matches what we are looking for, that’s when the magic happens, so we will simulate a webhook with the correct payload:
+But once our payload matches what we are looking for, that's when the magic happens, so we will simulate a webhook with the correct payload:
 
 ```
 curl -H 'Content-Type: application/json' -d "{\"message\": \"Ansible is super cool\"}" 127.0.0.1:5000/endpoint

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Event-Driven Ansible has the potential to change the way we respond to issues an
 It opens up the possibilities of faster resolution and greater automated observation of our environments.
 
 ## Getting Started
+
 Now, let's install ansible-rulebook and start with our very first event.
 
 To install ansible-rulebook, we can install our Galaxy Collection, which has a playbook to install everything we need.
@@ -25,7 +26,7 @@ To install ansible-rulebook, we can install our Galaxy Collection, which has a p
 
 Once the Collection is installed, you can run the install-rulebook-cli.yml playbook. This will install everything you need to get started with ansible-rulebook on the command line. This is currently supported for Mac and Fedora.
 
-If you want to contribute to ansible-rulebook, you can also fork the following [GitHub repository](https://github.com/ansible/ansible-rulebook). This repository also contains instructions for setting up your development environment and how to build a test container. 
+If you want to contribute to ansible-rulebook, you can also fork the following [GitHub repository](https://github.com/ansible/ansible-rulebook). This repository also contains instructions for setting up your development environment and how to build a test container.
 
 Let's build an example rulebook that will trigger an action from a webhook. We will be looking for a specific payload from the webhook, and if that condition is met from the webhook event, then ansible-rulebook with trigger the desired action. Below is our example rulebook:
 
@@ -54,9 +55,9 @@ Let's build an example rulebook that will trigger an action from a webhook. We w
          name: say-what.yml
 ```
 
-If we look at this example, we can see the structure of the rulebook. Our sources, rules and actions are defined. We are using the webhook source plugin from our ansible.eda collection, and we are looking for a message payload from our webhook that contains “Ansible is super cool”. Once this condition has been met, our defined action will trigger which in this case is to trigger a playbook. 
+If we look at this example, we can see the structure of the rulebook. Our sources, rules and actions are defined. We are using the webhook source plugin from our ansible.eda collection, and we are looking for a message payload from our webhook that contains "Ansible is super cool". Once this condition has been met, our defined action will trigger which in this case is to trigger a playbook.
 
-One important thing to take note of ansible-rulebook is that it is not like ansible-playbook which runs a playbook and once the playbook has been completed it will exit. With ansible-rulebook, it will continue to run waiting for events and matching those events, it will only exit upon a shutdown action or if there is an issue with the event source itself, for example if a website you are watching with the url-check plugin stops working. 
+One important thing to take note of ansible-rulebook is that it is not like ansible-playbook which runs a playbook and once the playbook has been completed it will exit. With ansible-rulebook, it will continue to run waiting for events and matching those events, it will only exit upon a shutdown action or if there is an issue with the event source itself, for example if a website you are watching with the url-check plugin stops working.
 
 With our rulebook built, we will simply tell ansible-rulebook to use it as a ruleset and wait for events:
 
@@ -107,16 +108,15 @@ ok: [localhost] => {
 }
 
 PLAY RECAP *********************************************************************
-localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
 INFO:root:Waiting for event
 
 ```
 
-We can see from the output above, that the condition was met from the webhook and ansible-rulebook then triggered our action which was to run_playbook. The playbook we defined is then triggered and once it completes we can see we revert back to “Waiting for event”. 
+We can see from the output above, that the condition was met from the webhook and ansible-rulebook then triggered our action which was to run_playbook. The playbook we defined is then triggered and once it completes we can see we revert back to "Waiting for event".
 
-Event-Driven Ansible opens up the possibilities of faster resolution and greater automated observation of our environments. It has the possibility of simplifying the lives of many technical and sleep-deprived engineers. The current `ansible-rulebook` is easy to learn and work with, and the graphical user interface `EDA-Server` will simplify this further. 
-
+Event-Driven Ansible opens up the possibilities of faster resolution and greater automated observation of our environments. It has the possibility of simplifying the lives of many technical and sleep-deprived engineers. The current `ansible-rulebook` is easy to learn and work with, and the graphical user interface `EDA-Server` will simplify this further.
 
 [EDA Server](https://github.com/ansible/eda-server)
 


### PR DESCRIPTION
This is for some reason necessary again even though was #32 merged but `no-smart-quotes` is triggered yet again, see https://github.com/ansible/event-driven-ansible/actions/runs/3289246797/jobs/5420548015#step:5:79

This PR:
- replaces Unicode quotes again
- removes end-of-line whitespaces

related: #30 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>