### PR TITLE
Dynatrace demo

### DIFF
--- a/demos/dynatrace-demo/fake_app.py
+++ b/demos/dynatrace-demo/fake_app.py
@@ -1,0 +1,25 @@
+import asyncio
+import sys
+from aiohttp import web
+from os import environ
+from aiohttp.web_request import Request
+from aiohttp.web_response import Response
+
+routes = web.RouteTableDef()
+
+
+@routes.get("/health")
+async def health(request: Request) -> Response:
+    return web.json_response({"status": "RUNNING"})
+
+
+@routes.get("/down")
+async def down(request: Request) -> Response:
+    # simulate program crashing
+    sys.exit(1)
+
+if __name__ == "__main__":
+    app = web.Application()
+    app.add_routes(routes)
+    port = int(environ.get("HTTP_PORT", 5080))
+    web.run_app(app=app, port=port)

--- a/demos/dynatrace-demo/instructions.md
+++ b/demos/dynatrace-demo/instructions.md
@@ -1,0 +1,55 @@
+# Ansible Rulebook + Dynatrace DEMO
+
+## Description
+In this demo we will register a host to Dynatrace and set up a webhook to send
+problem notifications to ansible-rulebook CLI. Dynatrace monitors the
+availability of a process. Upon receiving a problem notification the ansible-
+rulebook CLI runs a remedy playbook to restart the process.
+
+## Instructions
+### Nodes or instances
+* Rulebook Node: The node where the ansible-rulebook CLI is running
+* Client Node: The node where the monitored process is running
+* Dynatrace Console: An active Dyntrace tenant and its web console
+
+### Set up client node
+1. Prepare a VM with host name called `lamp`
+2. Install Dynatrace OneAgent. Host `lamp` then should appear in Dynatrace
+console
+3. Have python3 installed
+4. Copy `fake_app.py` under path `/root/fake-app`. Run `python3 fake_app.py`.  
+`fake_app.py` is a web app with two GET endpoints running on port 5080.  
+`<lamp ip>:5080/health` will return `{"status": "RUNNING"}`.  
+`<lamp ip>:5080/down` will force the app to exit, simulating a process
+crashing.
+5. Make the client node ansible accessible from the rulebook node.
+
+### Set up the rulebook node
+1. Have ansible-rulebook CLI and its dependencies installed
+2. Have ansible.eda collection installed by ansible-galaxy
+3. Update `inventory.yml` with correct ip and user to access the client node
+4. Start the rulebook CLI:
+```
+  ansible-rulebook -i demos/dynatrace-demo/inventory.yml --rules demos/dynatrace-demo/rulebook.yml
+```
+This rulebook starts an alertmanager source that listens on port 5050
+
+### Configure Dynatrace
+1. On the console window go to `Settings/Integrations/Problem notifications`.
+Add a new notification with type `Custom Integration`. Set the webhook URL to
+`<rulebook node ip>:5050/dynatrace`. Make sure the URL is publicly accessible.
+Otherwise use a reverse proxy.
+2. Go to `Settings/Processes and containers/Process availability`. Add a new
+monitoring rule. Add a new detection rule with process property = `Command line`
+and Condition = `$suffix(fake_app.py)`. Save the monitored rule name as
+`pythonmain`
+
+### Test
+1. Use a curl or similar command to request `http://<lamp ip>:5080/health`. It
+should response properly
+2. Make request `http://<lamp ip>:5080/down` to shutdown the fake_app
+3. Wait a few minutes and observe Dynatrace console window. The Problems page
+should report a problem
+4. The rulebook CLI should respond to the problem and run a playbook
+5. Dynatrace should then change the problem status to `Closed`
+6. Verify `http://<lamp ip>:5080/health` is responding again

--- a/demos/dynatrace-demo/inventory.yml
+++ b/demos/dynatrace-demo/inventory.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    lamp:
+      ansible_host: 192.168.1.171
+      ansible_user: root

--- a/demos/dynatrace-demo/playbook.yml
+++ b/demos/dynatrace-demo/playbook.yml
@@ -1,0 +1,7 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Restart main
+      shell: "(cd /root/fake-app; python3 fake_app.py >/dev/null 2>&1 &)"
+      async: 10
+      poll: 0

--- a/demos/dynatrace-demo/rulebook.yml
+++ b/demos/dynatrace-demo/rulebook.yml
@@ -1,0 +1,23 @@
+---
+- name: dynatrace demo
+  hosts: all
+  sources:
+    - name: alertmanager
+      ansible.eda.alertmanager:
+        host: 0.0.0.0
+        port: 5050
+        data_alerts_path:
+        data_host_path: ImpactedEntityNames
+        skip_original_data: true
+      filters:
+        - ansible.eda.json_filter:
+            exclude_keys:
+              - ProblemDetailsMarkdown
+              - ProblemDetailsText
+              - ProblemDetailsJSON
+  rules:
+    - name: restart process
+      condition: event.alert.ProblemTitle == "No process found for rule pythonmain" and event.alert.State == "OPEN"
+      action:
+        run_playbook:
+          name: demos/dynatrace-demo/playbook.yml

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -59,4 +59,5 @@ issues: http://example.com/issue/tracker
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This
 # uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
 # and '.git' are always filtered
-build_ignore: []
+build_ignore:
+  - demos


### PR DESCRIPTION
We can use the existing (enhanced by #42) alertmanager and json_filter to integrate EDA with Dynatrace. Here is the an example on how to monitor the availability of a process and restart it if it crashes.

After some discussion with Ben we felt we should place our demos in this repository. I created demos folder which is excluded from the ansible-galaxy collection installation