### PR TITLE
Fix intermittently failing webhook unit test

### DIFF
--- a/tests/unit/event_source/test_webhook.py
+++ b/tests/unit/event_source/test_webhook.py
@@ -28,7 +28,7 @@ async def cancel_code(server_task):
 async def test_cancel():
     queue = asyncio.Queue()
 
-    args = {"host": "localhost", "port": 8000}
+    args = {"host": "127.0.0.1", "port": 8000}
     plugin_task = asyncio.create_task(start_server(queue, args))
     cancel_task = asyncio.create_task(cancel_code(plugin_task))
 
@@ -40,7 +40,7 @@ async def test_cancel():
 async def test_post_endpoint():
     queue = asyncio.Queue()
 
-    args = {"host": "localhost", "port": 8000}
+    args = {"host": "127.0.0.1", "port": 8000}
     plugin_task = asyncio.create_task(start_server(queue, args))
 
     task_info = {


### PR DESCRIPTION
Ensure the test always uses ipv4 loopback address instead of 'localhost' to avoid edge cases where the web server and post function will use different versions of IP.
Add empty __init__.py to allow for running test locally.