### PR TITLE
Add Github workflow tests for ansible-rulebook installer

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -1,0 +1,83 @@
+name: Tests for ansible-rulebook installer
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'roles/install_ansible_rulebook/**'
+      - 'playbooks/install_rulebook_cli.yml'
+
+jobs:
+  cli-installer-tests:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - macos-11
+        include:
+          - os: ubuntu-latest
+            container: quay.io/ansible/fedora35-test-container:3.2.0
+            python-version: "3.10"
+          - os: ubuntu-latest
+            container: quay.io/ansible/fedora36-test-container:4.8.0
+            python-version: "3.10"
+          - os: ubuntu-latest
+            container: quay.io/ansible/ubuntu2204-test-container:4.8.0
+            python-version: "3.10"
+          - os: ubuntu-latest
+            container: docker.io/archlinux:latest
+            pkg_install_cmd: pacman -Sy && pacman -S --noconfirm python python-pip python-setuptools
+            ansible_playbook: true
+          - os: ubuntu-latest
+            container: docker.io/debian:latest
+            pkg_install_cmd: apt update && apt install -y init python3 python3-pip python3-setuptools
+            ansible_playbook: true
+          - os: ubuntu-latest
+            container: registry.access.redhat.com/ubi8:latest
+            pkg_install_cmd: dnf install -y python39 python39-devel
+            ansible_playbook: true
+          - os: ubuntu-latest
+            container: registry.access.redhat.com/ubi9:latest
+            pkg_install_cmd: dnf install -y python3 python3-devel
+            ansible_playbook: true
+        python-version:
+          - "3.10"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: ansible_collections/ansible/eda
+
+      - name: Set up Python ${{ matrix.python-version }}
+        if: matrix.ansible_playbook == false 
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install ansible
+        if: matrix.ansible_playbook == false 
+        run: python3 -m pip install ansible
+
+      - name: Install collection
+        if: matrix.ansible_playbook == false 
+        run: ansible-galaxy collection install .
+        working-directory: ansible_collections/ansible/eda
+
+      - name: Run ansible-test integration test
+        if: matrix.ansible_playbook == false 
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            ansible-test integration --docker ${{ matrix.container }} --python ${{ matrix.python-version }} -v
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            ansible-test integration --local -v
+          fi
+        working-directory: ansible_collections/ansible/eda
+        env:
+          ANSIBLE_TEST_PREFER_PODMAN: 1
+
+      - name: Run ansible-playbook test
+        if: matrix.ansible_playbook == true
+        run: |
+          podman run -v .:/eda ${{ matrix.container }} bash -c "${{ matrix.pkg_install_cmd }} && python3 -m pip install ansible && ansible-galaxy collection install /eda && ansible-playbook -i localhost, -c local ansible.eda.install_rulebook_cli -v && ansible-rulebook -h"
+        working-directory: ansible_collections/ansible/eda

--- a/tests/integration/targets/test_install_ansible_rulebook/files/hello.yml
+++ b/tests/integration/targets/test_install_ansible_rulebook/files/hello.yml
@@ -1,0 +1,14 @@
+---
+- name: Hello World
+  hosts: all
+  sources:
+    - ansible.eda.range:
+        limit: 3
+  rules:
+    - name: Hello World
+      condition: event.i == 1
+      action:
+        run_module:
+          name: ansible.builtin.debug
+          module_args:
+            msg: Hello World!

--- a/tests/integration/targets/test_install_ansible_rulebook/files/inventory
+++ b/tests/integration/targets/test_install_ansible_rulebook/files/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/integration/targets/test_install_ansible_rulebook/tasks/main.yml
+++ b/tests/integration/targets/test_install_ansible_rulebook/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Include install_ansible_rulebook role
+  ansible.builtin.include_role:
+    name: install_ansible_rulebook
+
+- name: Copy files for test
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /tmp/
+    mode: 0644
+  loop:
+    - hello.yml
+    - inventory
+
+- name: Run a simple rulebook
+  ansible.builtin.command:
+    cmd: ansible-rulebook -i /tmp/inventory --rulebook /tmp/hello.yml
+  register: result
+  environment:
+    JAVA_HOME: "{{ java_home_path }}"
+  changed_when: result.rc != 0
+  failed_when:
+    - result.rc != 0
+    - '"Hello World!" not in result.stdout'


### PR DESCRIPTION
Adding a Github workflow to run ansible-test against the `install_ansible_rulebook` role whenever changes are made. This workflow will cover tests for Debian, RHEL-like and MacOS systems.

Also adding a new test role under `roles/test` which is required by ansible-test.

This PR depends on changes made in #51.