### PR TITLE
Override RHEL8 package_list var for CLI installer

### DIFF
--- a/roles/install_ansible_rulebook/tasks/main.yml
+++ b/roles/install_ansible_rulebook/tasks/main.yml
@@ -3,6 +3,13 @@
   ansible.builtin.include_vars:
     file: "{{ ansible_os_family }}.yml"
 
+- name: Include RHEL8 override vars
+  ansible.builtin.include_vars:
+    file: RedHat-8.yml
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "8"
+
 - name: Ensure dependencies are installed
   become: "{{ 'false' if ansible_distribution == 'MacOSX' else 'true' }}"
   ansible.builtin.package:

--- a/roles/install_ansible_rulebook/vars/RedHat-8.yml
+++ b/roles/install_ansible_rulebook/vars/RedHat-8.yml
@@ -1,0 +1,8 @@
+package_list:
+  - git
+  - python39
+  - python39-pip
+  - python39-devel
+  - java-17-openjdk-devel
+  - maven
+  - gcc


### PR DESCRIPTION
The python3* packages in RHEL8 differ to other OS' in that they point to an older version of Python (3.6). We need to override the package_list var for RHEL8 to ensure that Python3.9 is installed, not 3.6.