### PR TITLE
Added RabbitMQ event_source

### DIFF
--- a/plugins/event_source/rabbitmq.py
+++ b/plugins/event_source/rabbitmq.py
@@ -1,0 +1,75 @@
+"""
+rabbitmq.py
+An ansible-rulebook event source plugin for receiving events via RabbitMQ
+
+author:
+    - Timothy Test (@ttestscripting)
+
+Arguments:
+    host       The RabbitMQ host
+    port       The port for RabbitMQ
+               Default 5672
+    v_host:    Virtual Host
+               Default '/'
+    username:  The RabbitMQ username
+               Default guest
+    password:  The RabbitMQ password
+               Default guest
+    queue:     queue to watch
+"""
+
+import asyncio
+import logging
+import aio_pika
+from typing import Any, Dict
+
+async def main(queue: asyncio.Queue, args: Dict[str, Any]):
+
+    logger = logging.getLogger()
+
+    rabbitmq_host = args.get("host")
+    rabbitmq_port = args.get("port", "5672")
+    rabbitmq_v_host = args.get("v_host", "/")
+    rabbitmq_username = args.get("username", "guest")
+    rabbitmq_password = args.get("password", "guest")
+    rabbitmq_queue = args.get("queue")
+    # TODO add options for SSL
+    connection = await aio_pika.connect_robust(
+        host=rabbitmq_host,
+        login=rabbitmq_username,
+        password=rabbitmq_password,
+        port=rabbitmq_port,
+        virtualhost=rabbitmq_v_host
+    )
+
+    async with connection:
+
+        # Creating channel
+        channel: aio_pika.abc.AbstractChannel = await connection.channel()
+
+        # Declaring queue
+        mq_queue: aio_pika.abc.AbstractQueue = await channel.declare_queue(rabbitmq_queue)
+
+        async with mq_queue.iterator() as queue_iter:
+            async for message in queue_iter:
+                async with message.process():
+                    logger.info(message.body.decode())
+                    data = dict(
+                           message_body=message.body.decode(),
+                           meta=dict(host=rabbitmq_host,
+                                     queue=rabbitmq_queue,
+                                     v_host=rabbitmq_v_host,
+                                     message_info=message.info()),
+                          )
+                    await queue.put(data)
+                    logger.info(data)
+                    if mq_queue.name in message.body.decode():
+                        break
+
+if __name__ == "__main__":
+
+    class MockQueue:
+        async def put(self, event):
+            print(event)
+
+    asyncio.run(main(MockQueue(), {"host": "localhost", "port": "5672", "queue": "test"}))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ aiokafka
 watchdog
 asyncio
 dpath
+aio_pika

--- a/rulebooks/rabbitmq-rules.yml
+++ b/rulebooks/rabbitmq-rules.yml
@@ -1,0 +1,13 @@
+---
+- name: Listen for events on a rabbitmq
+  hosts: all
+  sources:
+    - ansible.eda.rabbitmq:
+        host: localhost
+        port: 5672
+        queue: hello
+  rules:
+    - name: queue is hello and message body is world
+      condition: event.meta.queue == "hello" and event.message_body == "world"
+      action:
+        debug:


### PR DESCRIPTION
This PR adds support for RabbitMQ as an event source and includes an example rulebook. It only supports user/pass auth in its present state. 