### PR TITLE
Remove PIP_NO_BINARY env var

### DIFF
--- a/roles/install_ansible_rulebook/tasks/main.yml
+++ b/roles/install_ansible_rulebook/tasks/main.yml
@@ -49,7 +49,6 @@
 
 - name: Install ansible-rulebook
   environment:
-    PIP_NO_BINARY: jpy
     JAVA_HOME: "{{ java_home_path }}"
   ansible.builtin.pip:
     name: ansible-rulebook


### PR DESCRIPTION
Closes [AAP-7759](https://issues.redhat.com/browse/AAP-7759). Removing env var from installer playbook since we no longer need to force compilation of JPY from source.