### PR TITLE
Allow installation of collection from source

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -79,5 +79,10 @@ jobs:
       - name: Run ansible-playbook test
         if: matrix.ansible_playbook == true
         run: |
-          podman run -v .:/eda ${{ matrix.container }} bash -c "${{ matrix.pkg_install_cmd }} && python3 -m pip install ansible && ansible-galaxy collection install /eda && ansible-playbook -i localhost, -c local ansible.eda.install_rulebook_cli -v && ansible-rulebook -h"
+          podman run -v .:/eda ${{ matrix.container }} bash -c '${{ matrix.pkg_install_cmd }} \
+          && python3 -m pip install ansible && ansible-galaxy collection install /eda \
+          && ansible-playbook -i localhost, -c local \
+          -e eda_collection_pkg_name="git+https://github.com/ansible/event-driven-ansible" \
+          ansible.eda.install_rulebook_cli \
+          -v && ansible-rulebook -h'
         working-directory: ansible_collections/ansible/eda

--- a/roles/install_ansible_rulebook/README.md
+++ b/roles/install_ansible_rulebook/README.md
@@ -14,11 +14,20 @@ Some tasks in this role require [privilege escalation](https://docs.ansible.com/
 Example Playbook
 ----------------
 
+```
 - name: Install ansible-rulebook
   hosts: all
   gather_facts: true
   roles:
     - install_ansible_rulebook
+```
+
+
+By default, the role will install the EDA collection published on Ansible Galaxy. If you wish to install directly from the repository source you can define the following variable in your inventory file:
+
+```
+eda_collection_pkg_name: "git+https://github.com/ansible/event-driven-ansible"
+```
 
 License
 -------

--- a/roles/install_ansible_rulebook/defaults/main.yml
+++ b/roles/install_ansible_rulebook/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+eda_collection_pkg_name: ansible.eda

--- a/roles/install_ansible_rulebook/tasks/main.yml
+++ b/roles/install_ansible_rulebook/tasks/main.yml
@@ -56,7 +56,7 @@
     state: latest # noqa package-latest
 
 - name: Install collections
-  ansible.builtin.command: ansible-galaxy collection install ansible.eda community.general
+  ansible.builtin.command: "ansible-galaxy collection install {{ eda_collection_pkg_name }} community.general"
   register: collection_install
   changed_when: collection_install.rc != 0
   failed_when: collection_install.rc != 0

--- a/tests/integration/targets/test_install_ansible_rulebook/tasks/main.yml
+++ b/tests/integration/targets/test_install_ansible_rulebook/tasks/main.yml
@@ -2,6 +2,12 @@
 - name: Include install_ansible_rulebook role
   ansible.builtin.include_role:
     name: install_ansible_rulebook
+    apply:
+      environment:
+        #  override ansible-test collection directory. See https://issues.redhat.com/browse/AAP-7849
+        ANSIBLE_COLLECTIONS_PATH: "~/.ansible/collections/ansible_collections/"
+  vars:
+    eda_collection_pkg_name: "git+https://github.com/ansible/event-driven-ansible"
 
 - name: Copy files for test
   ansible.builtin.copy:


### PR DESCRIPTION
We want to allow for the installation of the EDA collection from the source repo. This will allow us to work around issues such as hitting Galaxy API limits in our workflows.