### PR TITLE
Add AWS Cloudtrail event source plugin

### DIFF
--- a/plugins/event_source/aws_cloudtrail.py
+++ b/plugins/event_source/aws_cloudtrail.py
@@ -5,6 +5,9 @@ An ansible-rulebook event source module for getting events from an AWS CloudTrai
 
 Arguments:
     connection        - Parameters used to create AWS session
+                        supporters parameters are: region_name, api_version,
+                        use_ssl, verify, endpoint_url, aws_access_key_id,
+                        aws_secret_access_key, aws_session_token
     lookup_attributes - The optional list of lookup attributes.
                         lookup attribute are dictionnary with an AttributeKey (string),
                         which specifies an attribute on which to filter the events
@@ -23,7 +26,6 @@ Example:
               AttributeValue: 'ec2.amazonaws.com'
             - AttributeKey: 'ReadOnly'
               AttributeValue: 'true'
-            Username: ansible
         event_category: management
 
 """

--- a/plugins/event_source/aws_cloudtrail.py
+++ b/plugins/event_source/aws_cloudtrail.py
@@ -6,9 +6,10 @@ An ansible-rulebook event source module for getting events from an AWS CloudTrai
 Arguments:
     connection        - Parameters used to create AWS session
     lookup_attributes - The optional list of lookup attributes.
-                        lookup attribute are dictionnary with an AttributeKey (string), 
-                        which specifies an attribute on which to filter the events returned and an
-                        AttributeValue (string) which specifies a value for the specified AttributeKey
+                        lookup attribute are dictionnary with an AttributeKey (string),
+                        which specifies an attribute on which to filter the events
+                        returned and an AttributeValue (string) which specifies
+                        a value for the specified AttributeKey
     event_category    - The optional event category to return. (e.g. 'insight')
     delay             - The number of seconds to wait between polling (default 10sec)
 

--- a/plugins/event_source/aws_cloudtrail.py
+++ b/plugins/event_source/aws_cloudtrail.py
@@ -1,0 +1,118 @@
+"""
+aws_cloudtrail.py
+
+An ansible-rulebook event source module for getting events from an AWS CloudTrail
+
+Arguments:
+    connection - Parameters used to create AWS session
+    lookup_attributes - A dictionary representing the filters to be applied.
+    event_category - Specifies the event category.
+    delay - The number of seconds to wait between polling (default 10sec)
+
+Example:
+
+    - ansible.eda.aws_cloudtrail:
+        connection:
+            aws_access_key_id: access123456789
+            aws_secret_access_key: secret123456789
+            region_name: us-east-1
+            profile_name: default
+        lookup_attributes:
+            EventSource: ec2.amazonaws.com
+            Username: ansible
+        event_category: management
+
+"""
+
+import asyncio
+import json
+from datetime import datetime
+from typing import Any, Dict
+
+import boto3.session
+
+
+def _parse_user_inputs(**kwargs):
+    params = {}
+    attributes = kwargs.get("lookup_attributes")
+    if attributes:
+        filters_list = []
+        for k, v in attributes.items():
+            filter_dict = {"AttributeKey": k, "AttributeValue": v}
+            if isinstance(v, bool):
+                filter_dict["AttributeValue"] = str(v).lower()
+            elif isinstance(v, int):
+                filter_dict["AttributeValue"] = str(v)
+        filters_list.append(filter_dict)
+        params["LookupAttributes"] = filters_list
+
+    event_category = kwargs.get("event_category")
+    if event_category:
+        params["EventCategory"] = event_category
+    return params
+
+
+def _cloudtrail_event_to_dict(event):
+    event["EventTime"] = event["EventTime"].isoformat()
+    event["CloudTrailEvent"] = json.loads(event["CloudTrailEvent"])
+    return event
+
+
+def get_events(events, last_event_ids):
+    event_time = None
+    event_ids = []
+    result = []
+    for e in events:
+        # skip last event
+        if last_event_ids and e["EventId"] in last_event_ids:
+            continue
+        if event_time is None or event_time < e["EventTime"]:
+            event_time = e["EventTime"]
+            event_ids = [e["EventId"]]
+        elif event_time == e["EventTime"]:
+            event_ids.append(e["EventId"])
+        result.append(e)
+    return result, event_time, event_ids
+
+
+class AnsibleAwsCloudTrailEventClient(object):
+    def __init__(self, connection):
+        session = boto3.session.Session(**connection)
+        self.client = session.client("cloudtrail")
+
+    def lookup_events(self, **kwargs):
+        paginator = self.client.get_paginator("lookup_events")
+        return paginator.paginate(**kwargs).build_full_result().get("Events", [])
+
+
+async def main(queue: asyncio.Queue, args: Dict[str, Any]):
+    delay = args.get("delay", 10)
+    client = AnsibleAwsCloudTrailEventClient(args.get("connection"))
+    params = _parse_user_inputs(**args)
+    params["StartTime"] = datetime.utcnow()
+
+    event_time = None
+    event_ids = []
+
+    while True:
+        if event_time is not None:
+            params["StartTime"] = event_time
+
+        events = client.lookup_events(**params)
+        events, c_event_time, c_event_ids = get_events(events, event_ids)
+        for event in events:
+            await queue.put(_cloudtrail_event_to_dict(event))
+
+        event_ids = c_event_ids or event_ids
+        event_time = c_event_time or event_time
+
+        await asyncio.sleep(delay)
+
+
+if __name__ == "__main__":
+
+    class MockQueue:
+        async def put(self, event):
+            print(event)
+
+    asyncio.run(main(MockQueue(), {}))

--- a/plugins/event_source/aws_cloudtrail.py
+++ b/plugins/event_source/aws_cloudtrail.py
@@ -75,13 +75,13 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
 
     session = get_session()
     params = {}
-    for k,v in ARGS_MAPPING.items():
+    for k, v in ARGS_MAPPING.items():
         if args.get(k) is not None:
             params[v] = args.get(k)
 
     params["StartTime"] = datetime.utcnow()
 
-    async with session.create_client('cloudtrail', **args.get("connection")) as client:
+    async with session.create_client("cloudtrail", **args.get("connection")) as client:
         event_time = None
         event_ids = []
         while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ aiokafka
 watchdog
 systemd-python
 dpath
-botocore
-boto3
+aiobotocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ aiokafka
 watchdog
 systemd-python
 dpath
+botocore
+boto3

--- a/tests/integration/event_source_aws_cloudtrail/test_awscloudtrail_rules.yml
+++ b/tests/integration/event_source_aws_cloudtrail/test_awscloudtrail_rules.yml
@@ -4,10 +4,7 @@
   sources:
     - ansible.eda.aws_cloudtrail:
         connection:
-          region: '{{ aws_region | default(omit) }}'
-          aws_access_key: '{{ aws_access_key | default(omit) }}'
-          aws_secret_key: '{{ aws_secret_key | default(omit) }}'
-          security_token: '{{ security_token | default(omit) }}'
+          region: 'us-east-1'
         delay: 5
   rules:
     - name: match key pair creation event

--- a/tests/integration/event_source_aws_cloudtrail/test_awscloudtrail_rules.yml
+++ b/tests/integration/event_source_aws_cloudtrail/test_awscloudtrail_rules.yml
@@ -1,0 +1,22 @@
+- name: test aws cloudtrail source plugin
+  hosts: localhost
+
+  sources:
+    - ansible.eda.aws_cloudtrail:
+        connection:
+          region: '{{ aws_region | default(omit) }}'
+          aws_access_key: '{{ aws_access_key | default(omit) }}'
+          aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+          security_token: '{{ security_token | default(omit) }}'
+        delay: 5
+  rules:
+    - name: match key pair creation event
+      condition: event.CloudTrailEvent.eventName == 'CreateKeyPair' and event.CloudTrailEvent.requestParameters.keyName == '{{ test_ec2_key_pair_name }}'
+      action:
+        debug:
+          msg: "SUCCESS"
+
+    - name: match key pair creation event
+      condition: event.CloudTrailEvent.eventName == 'DeleteKeyPair' and event.CloudTrailEvent.requestParameters.keyName == '{{ test_ec2_key_pair_name }}'
+      action:
+        shutdown:

--- a/tests/integration/event_source_aws_cloudtrail/test_awscloudtrail_rules.yml
+++ b/tests/integration/event_source_aws_cloudtrail/test_awscloudtrail_rules.yml
@@ -13,7 +13,7 @@
         debug:
           msg: "SUCCESS"
 
-    - name: match key pair creation event
+    - name: match key pair deletion event
       condition: event.CloudTrailEvent.eventName == 'DeleteKeyPair' and event.CloudTrailEvent.requestParameters.keyName == '{{ test_ec2_key_pair_name }}'
       action:
         shutdown:


### PR DESCRIPTION
This PR adds support to AWS Cloudtrail as an event source and includes an example rulebook.