### PR TITLE
Allow empty endpoint in webhook plugin

### DIFF
--- a/plugins/event_source/webhook.py
+++ b/plugins/event_source/webhook.py
@@ -18,7 +18,7 @@ from aiohttp import web
 routes = web.RouteTableDef()
 
 
-@routes.post("/{endpoint}")
+@routes.post(r"/{endpoint:.*}")
 async def webhook(request: web.Request):
     payload = await request.json()
     endpoint = request.match_info["endpoint"]


### PR DESCRIPTION
Allow an empty endpoint for webhook plugin
Fixes https://github.com/ansible/event-driven-ansible/issues/57
Fixes https://github.com/ansible/ansible-rulebook/issues/236