### PR TITLE
convert journald fields to strings

### DIFF
--- a/plugins/event_source/journald.py
+++ b/plugins/event_source/journald.py
@@ -41,14 +41,7 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]):
         for entry in journal_stream:
             stream_dict = {}
             for field in entry:
-                if field:
-                    if (
-                        "_TIMESTAMP" not in field
-                        and "_BOOT_ID" not in field
-                        and "_MACHINE_ID" not in field
-                        and "__CURSOR" not in field
-                    ):
-                        stream_dict[field.lower()] = entry[field]
+                stream_dict[field.lower()] = f"{entry[field]}"
 
             await queue.put(dict(journald=stream_dict))
             await asyncio.sleep(delay)


### PR DESCRIPTION
This PR:
- converts all journald fields to strings so we don't have to worry about UUID and such
- ensures all journald fields are added to the dict
- closes #85 