### PR TITLE
Increase test timeouts

### DIFF
--- a/tests/integration/event_source_webhook/test_webhook_source.py
+++ b/tests/integration/event_source_webhook/test_webhook_source.py
@@ -9,7 +9,7 @@ import requests
 from ..utils import TESTS_PATH, CLIRunner
 
 
-def wait_for_events(proc: subprocess.Popen, timeout: float = 5.0):
+def wait_for_events(proc: subprocess.Popen, timeout: float = 15.0):
     """
     Wait for events to be processed by ansible-rulebook, or timeout.
     Requires the process to be running in debug mode.
@@ -80,7 +80,7 @@ def test_webhook_source_with_busy_port(subprocess_teardown):
     wait_for_events(proc1)
 
     proc2 = CLIRunner(rules=rules_file, debug=True).run_in_background()
-    proc2.wait(timeout=5)
+    proc2.wait(timeout=15)
     stdout, _unused_stderr = proc2.communicate()
     assert "address already in use" in stdout.decode()
     assert proc2.returncode == 1

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from . import TESTS_PATH
 
-DEFAULT_TEST_TIMEOUT: int = 5
+DEFAULT_TEST_TIMEOUT: int = 25
 
 
 @dataclass


### PR DESCRIPTION
We need to increase the max timeout for the ppc641e arch. This is a temporary solution until we implement config management to handle different architectures.
Ref: https://issues.redhat.com/browse/AAP-9988