### PR TITLE
Fix failing integration tests due to upstream changes

### DIFF
--- a/tests/integration/event_source_kafka/test_kafka_rules.yml
+++ b/tests/integration/event_source_kafka/test_kafka_rules.yml
@@ -11,7 +11,7 @@
       condition: event.name == "some kafka event"
       action:
         debug:
-          msg: "SUCCESS"
+          msg: "Rule fired successfully"
 
     - name: stop
       condition: event.name == "stop"

--- a/tests/integration/event_source_kafka/test_kafka_source.py
+++ b/tests/integration/event_source_kafka/test_kafka_source.py
@@ -35,4 +35,4 @@ def test_kafka_source_sanity(kafka_producer: KafkaProducer):
 
     result = CLIRunner(rules=ruleset).run()
 
-    assert "'msg': 'SUCCESS'" in result.stdout.decode()
+    assert "Rule fired successfully" in result.stdout.decode()

--- a/tests/integration/event_source_url_check/test_url_check_rules.yml
+++ b/tests/integration/event_source_url_check/test_url_check_rules.yml
@@ -5,7 +5,7 @@
     - name: check site
       ansible.eda.url_check:
         urls:
-         - http://localhost:8000/{{ URL_ENDPOINT | default("") }}
+          - http://localhost:8000/{{ URL_ENDPOINT | default("") }}
   rules:
     - name: Endpoint is up
       condition: event.url_check.status == "up" and event.url_check.status_code == 200
@@ -13,18 +13,18 @@
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: UP
+            msg: "Endpoint available"
     - name: Endpoint is unavailable
       condition: event.url_check.status == "down" and event.url_check.status_code == 404
       action:
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: UNAVAILABLE
+            msg: "Endpoint unavailable"
     - name: Host offline
       condition: event.url_check.status == "down"
       action:
         run_module:
           name: ansible.builtin.debug
           module_args:
-            msg: DOWN
+            msg: "Endpoint down"

--- a/tests/integration/event_source_url_check/test_url_check_source.py
+++ b/tests/integration/event_source_url_check/test_url_check_source.py
@@ -34,8 +34,8 @@ def init_webserver():
 @pytest.mark.parametrize(
     "endpoint, expected_resp_data",
     [
-        pytest.param("", "UP", id="valid_endpoint"),
-        pytest.param("nonexistant", "UNAVAILABLE", id="invalid_endpoint"),
+        pytest.param("", "Endpoint available", id="valid_endpoint"),
+        pytest.param("nonexistant", "Endpoint unavailable", id="invalid_endpoint"),
     ],
 )
 def test_url_check_source_sanity(
@@ -77,5 +77,5 @@ def test_url_check_source_error_handling(subprocess_teardown):
 
     while line := runner.stdout.readline().decode():
         if "msg" in line:
-            assert '"msg": "DOWN"' in line
+            assert "Endpoint down" in line
             break

--- a/tests/integration/event_source_webhook/test_webhook_rules.yml
+++ b/tests/integration/event_source_webhook/test_webhook_rules.yml
@@ -8,7 +8,7 @@
       condition: event.payload.ping == "pong"
       action:
         debug:
-          msg: "SUCCESS"
+          msg: "Rule fired successfully"
 
     - name: shutdown
       condition: event.payload.shutdown is defined

--- a/tests/integration/event_source_webhook/test_webhook_source.py
+++ b/tests/integration/event_source_webhook/test_webhook_source.py
@@ -63,7 +63,7 @@ def test_webhook_source_sanity(subprocess_teardown, port: int):
         proc.terminate()
         stdout, _unused_stderr = proc.communicate()
 
-    assert "'msg': 'SUCCESS'" in stdout.decode()
+    assert "Rule fired successfully" in stdout.decode()
     assert f"'Host': '127.0.0.1:{port}'" in stdout.decode()
     assert proc.returncode == 0
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -48,9 +48,9 @@ class CLIRunner:
         if self.proc_id:
             args.extend(["--id", self.proc_id])
         if self.verbose:
-            args.append("--verbose")
+            args.append("-v")
         if self.debug:
-            args.append("--debug")
+            args.append("-vv")
 
         return args
 


### PR DESCRIPTION
Tests are failing due to upstream changes in ansible-rulebook.

1. The verbose and debug args merged into -v and -vv respectively.
2. The debug action no longer prepends 'msg' to messages.

Updating the CLIrunner to use new args and fixing the tests.

Closes [AAP-10111](https://issues.redhat.com/browse/AAP-10111).