### PR TITLE
Kafka plugin accepts non json string

### DIFF
--- a/extensions/eda/rulebooks/kafka-test-rules.yml
+++ b/extensions/eda/rulebooks/kafka-test-rules.yml
@@ -10,10 +10,10 @@
         group_id: testing
   rules:
     - name: Check defined
-      condition: event.i is defined
+      condition: event.body.i is defined
       action:
         debug:
     - name: Stop
-      condition: event.stop == true
+      condition: event.body == stop
       action:
         shutdown:

--- a/tests/integration/event_source_kafka/test_kafka_rules.yml
+++ b/tests/integration/event_source_kafka/test_kafka_rules.yml
@@ -6,14 +6,15 @@
         host: localhost
         port: 9092
         offset: earliest
+        encoding: ascii
   rules:
     - name: match kafka event
-      condition: event.name == "some kafka event"
+      condition: event.body.name == "some kafka event"
       action:
         debug:
           msg: "Rule fired successfully"
 
     - name: stop
-      condition: event.name == "stop"
+      condition: event.body == "stop"
       action:
         shutdown:

--- a/tests/integration/event_source_kafka/test_kafka_source.py
+++ b/tests/integration/event_source_kafka/test_kafka_source.py
@@ -27,7 +27,7 @@ def test_kafka_source_sanity(kafka_producer: KafkaProducer):
 
     msgs = [
         json.dumps({"name": "some kafka event"}).encode("ascii"),
-        json.dumps({"name": "stop"}).encode("ascii"),
+        "stop".encode("ascii"),
     ]
 
     for msg in msgs:

--- a/tests/unit/event_source/test_kafka.py
+++ b/tests/unit/event_source/test_kafka.py
@@ -27,7 +27,7 @@ class AsyncIterator:
     async def __anext__(self):
         if self.count < 2:
             mock = MagicMock()
-            mock.value = f'{{"i": {self.count}}}'
+            mock.value = f'{{"i": {self.count}}}'.encode("utf-8")
             self.count += 1
             return mock
         else:
@@ -54,5 +54,5 @@ def test_receive_from_kafka_place_in_queue(myqueue):
                 },
             )
         )
-        assert myqueue.queue[0] == {"i": 0}
+        assert myqueue.queue[0] == {"body": {"i": 0}}
         assert len(myqueue.queue) == 2


### PR DESCRIPTION
Parse json data if possible, otherwise leave it as pure string. Always place the kafa message under key body in the event placed in the queue.

Resolves AAP-9944: Kafka source plugin only supports json