### PR TITLE
Add security support to webhook plugin

### DIFF
--- a/extensions/eda/plugins/event_source/webhook.py
+++ b/extensions/eda/plugins/event_source/webhook.py
@@ -4,17 +4,24 @@ webhook.py
 An ansible-rulebook event source module for receiving events via a webhook.
 
 Arguments:
-    host: The hostname to listen to. Set to 0.0.0.0 to listen on all
-          interfaces. Defaults to 127.0.0.1
-    port: The TCP port to listen to.  Defaults to 5000
+    host:     The hostname to listen to. Set to 0.0.0.0 to listen on all
+              interfaces. Defaults to 127.0.0.1
+    port:     The TCP port to listen to.  Defaults to 5000
+    token:    The optional authentication token expected from client
+    certfile: The optional path to a certificate file to enable TLS support
+    keyfile:  The optional path to a key file to be used together with certfile
+    password: The optional password to be used when loading the certificate chain
 
 """
 
 import asyncio
-from typing import Any, Dict
+import logging
+import ssl
+from typing import Any, Callable, Dict
 
 from aiohttp import web
 
+logger = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
 
@@ -22,31 +29,68 @@ routes = web.RouteTableDef()
 async def webhook(request: web.Request):
     payload = await request.json()
     endpoint = request.match_info["endpoint"]
+    headers = dict(request.headers)
+    headers.pop("Authorization")
     data = {
         "payload": payload,
-        "meta": {"endpoint": endpoint, "headers": dict(request.headers)},
+        "meta": {"endpoint": endpoint, "headers": headers},
     }
     await request.app["queue"].put(data)
     return web.Response(text=endpoint)
 
 
+@web.middleware
+async def bearer_auth(request: web.Request, handler: Callable):
+    try:
+        scheme, token = request.headers["Authorization"].strip().split(" ")
+        if scheme != "Bearer":
+            raise web.HTTPUnauthorized(text="Only Bearer type is accepted")
+        elif token != request.app["token"]:
+            raise web.HTTPUnauthorized(text="Invalid authorization token")
+    except KeyError:
+        raise web.HTTPUnauthorized(reason="Missing authorization token")
+    except ValueError:
+        raise web.HTTPUnauthorized(text="Invalid authorization token")
+
+    return await handler(request)
+
+
 async def main(queue: asyncio.Queue, args: Dict[str, Any]):
-    app = web.Application()
+    if "token" in args:
+        app = web.Application(middlewares=[bearer_auth])
+        app["token"] = args["token"]
+    else:
+        app = web.Application()
     app["queue"] = queue
 
     app.add_routes(routes)
 
+    context = None
+    if "certfile" in args:
+        certfile = args.get("certfile")
+        keyfile = args.get("keyfile", None)
+        password = args.get("password", None)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        try:
+            context.load_cert_chain(certfile, keyfile, password)
+        except Exception:
+            logger.error("Failed to load certificates. Check they are valid")
+            raise
+
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(
-        runner, args.get("host") or "localhost", args.get("port") or 5000
+        runner,
+        args.get("host") or "localhost",
+        args.get("port") or 5000,
+        ssl_context=context,
     )
     await site.start()
 
     try:
         await asyncio.Future()
     except asyncio.CancelledError:
-        print("Plugin Task Cancelled")
+        logger.info("Webhook Plugin Task Cancelled")
     finally:
         await runner.cleanup()
 
@@ -57,4 +101,14 @@ if __name__ == "__main__":
         async def put(self, event):
             print(event)
 
-    asyncio.run(main(MockQueue(), {}))
+    asyncio.run(
+        main(
+            MockQueue(),
+            {
+                "port": 2345,
+                "token": "hello",
+                "certfile": "cert.pem",
+                "keyfile": "key.pem",
+            },
+        )
+    )

--- a/tests/integration/event_source_webhook/test_webhook_rules.yml
+++ b/tests/integration/event_source_webhook/test_webhook_rules.yml
@@ -3,6 +3,7 @@
   sources:
     - ansible.eda.webhook:
         port: "{{ WH_PORT | default(5000) }}"
+        token: "{{ SECRET }}"
   rules:
     - name: match webhook event
       condition: event.payload.ping == "pong"

--- a/tests/integration/event_source_webhook/test_webhook_source.py
+++ b/tests/integration/event_source_webhook/test_webhook_source.py
@@ -44,18 +44,20 @@ def test_webhook_source_sanity(subprocess_teardown, port: int):
 
     env = os.environ.copy()
     env["WH_PORT"] = str(port)
+    env["SECRET"] = "secret"
 
     rules_file = TESTS_PATH + "/event_source_webhook/test_webhook_rules.yml"
 
     proc = CLIRunner(
-        rules=rules_file, envvars="WH_PORT", env=env, debug=True
+        rules=rules_file, envvars="WH_PORT,SECRET", env=env, debug=True
     ).run_in_background()
     subprocess_teardown(proc)
 
     wait_for_events(proc)
 
     for msg in msgs:
-        requests.post(url, data=msg)
+        headers = {"Authorization": "Bearer secret"}
+        requests.post(url, data=msg, headers=headers)
 
     try:
         stdout, _unused_stderr = proc.communicate(timeout=5)

--- a/tests/unit/event_source/test_webhook.py
+++ b/tests/unit/event_source/test_webhook.py
@@ -15,7 +15,8 @@ async def post_code(server_task, info):
     payload = info["payload"]
 
     async with aiohttp.ClientSession() as session:
-        async with session.post(url, json=payload) as resp:
+        headers = {"Authorization": "Bearer secret"}
+        async with session.post(url, json=payload, headers=headers) as resp:
             print(resp.status)
 
     server_task.cancel()
@@ -29,7 +30,7 @@ async def cancel_code(server_task):
 async def test_cancel():
     queue = asyncio.Queue()
 
-    args = {"host": "127.0.0.1", "port": 8000}
+    args = {"host": "127.0.0.1", "port": 8000, "token": "secret"}
     plugin_task = asyncio.create_task(start_server(queue, args))
     cancel_task = asyncio.create_task(cancel_code(plugin_task))
 
@@ -41,7 +42,7 @@ async def test_cancel():
 async def test_post_endpoint():
     queue = asyncio.Queue()
 
-    args = {"host": "127.0.0.1", "port": 8000}
+    args = {"host": "127.0.0.1", "port": 8000, "token": "secret"}
     plugin_task = asyncio.create_task(start_server(queue, args))
 
     task_info = {


### PR DESCRIPTION
Client needs to send an bearer authorization token. Enable TLS support if a certificate file is provided.

Resolves AAP-4826: Add security check for webhook and alert manger's local server

We may make TLS default in a future PR.