### PR TITLE
[AAP-10473] Add a filter to insert source info

### DIFF
--- a/plugins/event_filter/insert_source_info.py
+++ b/plugins/event_filter/insert_source_info.py
@@ -1,0 +1,38 @@
+"""
+insert_source_info.py
+
+An ansible-rulebook event filter that sets the source name and type
+in the event meta field. A source name is needed to track where the
+event originated from. If the event meta already has a source.name
+or source.type field specified it will be ignored. This filter is
+automatically added to every source.
+
+Arguments:
+          source_name
+          source_type
+Example:
+    - ansible.eda.insert_source_info
+
+"""
+
+from typing import Any, Dict
+
+
+def main(
+    event: Dict[str, Any],
+    source_name: str,
+    source_type: str,
+) -> Dict[str, Any]:
+    if "meta" not in event:
+        event["meta"] = {}
+
+    if "source" not in event["meta"]:
+        event["meta"]["source"] = {}
+
+    if "name" not in event["meta"]["source"]:
+        event["meta"]["source"]["name"] = source_name
+
+    if "type" not in event["meta"]["source"]:
+        event["meta"]["source"]["type"] = source_type
+
+    return event

--- a/tests/unit/event_filter/test_insert_source_info.py
+++ b/tests/unit/event_filter/test_insert_source_info.py
@@ -1,0 +1,31 @@
+import pytest
+
+from plugins.event_filter.insert_source_info import main as sources_main
+
+EVENT_DATA_1 = [
+    (
+        {"myevent": {"name": "fred"}},
+        {"source_name": "my_source", "source_type": "stype"},
+        {
+            "myevent": {"name": "fred"},
+            "meta": {"source": {"name": "my_source", "type": "stype"}},
+        },
+    ),
+    (
+        {
+            "myevent": {"name": "barney"},
+            "meta": {"source": {"name": "origin", "type": "regular"}},
+        },
+        {"source_name": "my_source", "source_type": "stype"},
+        {
+            "myevent": {"name": "barney"},
+            "meta": {"source": {"name": "origin", "type": "regular"}},
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("data, args, expected", EVENT_DATA_1)
+def test_sources_main(data, args, expected):
+    data = sources_main(data, **args)
+    assert data == expected


### PR DESCRIPTION
The event payload can be embellished with source name and type under the meta key. It allows for tracking of the origin of the event

https://issues.redhat.com/browse/AAP-10473