### PR TITLE
Added an event filter to normalize keys in the event payload

### DIFF
--- a/extensions/eda/plugins/event_filter/normalize_keys.py
+++ b/extensions/eda/plugins/event_filter/normalize_keys.py
@@ -1,0 +1,69 @@
+"""
+normalize_keys.py:
+    An event filter that changes keys that contain non alpha numeric or
+    underscore to undersocres.
+    For instance, the key server-name becomes the new key server_name
+    If there are consecutive non alpa numeric or under score, they would
+    be coalesced into a single underscore
+    For instance the key server.com/&abc becomes server_com_abc
+    instead of server_com__abc
+
+    If there is a existing key with the normalized name, it will get overwritten
+    by default. If you don't want to over write it you can pass in overwrite: False
+    The default value of overwrite is True.
+
+Arguments:
+    * overwrite: Overwrite the values if there is a collision with a new key.
+
+Usage in a rulebook, a filter is usually attached to a source in the rulebook:
+    example1:
+    ....
+    sources:
+      - my_source:
+         ....
+        filters:
+          ansible.eda.normalize_keys:
+
+
+    example2: To prevent over writing of keys
+    ....
+    sources:
+      - my_source:
+         ....
+        filters:
+          ansible.eda.normalize_keys:
+            overwrite: False
+
+"""
+
+import multiprocessing as mp
+import re
+
+normalize_regex = re.compile("[^0-9a-zA-Z_]+")
+
+
+def main(event, overwrite=True):
+    logger = mp.get_logger()
+    logger.info("normalize_keys")
+    return _normalize_embedded_keys(event, overwrite, logger)
+
+
+def _normalize_embedded_keys(obj, overwrite, logger):
+    if isinstance(obj, dict):
+        new_dict = dict()
+        original_keys = list(obj.keys())
+        for key in original_keys:
+            new_key = normalize_regex.sub("_", key)
+            if new_key == key or new_key not in original_keys:
+                new_dict[new_key] = _normalize_embedded_keys(
+                    obj[key], overwrite, logger
+                )
+            elif new_key in original_keys and overwrite:
+                new_dict[new_key] = _normalize_embedded_keys(
+                    obj[key], overwrite, logger
+                )
+                logger.warning("Replacing existing key %s", new_key)
+        return new_dict
+    elif isinstance(obj, list):
+        return [_normalize_embedded_keys(item, overwrite, logger) for item in obj]
+    return obj

--- a/tests/unit/event_filter/test_normalize_keys.py
+++ b/tests/unit/event_filter/test_normalize_keys.py
@@ -1,0 +1,47 @@
+import pytest
+
+from extensions.eda.plugins.event_filter.normalize_keys import main as normalize_main
+
+TEST_DATA_1 = [
+    (
+        {"app": {"tar/get": "web/server"}},
+        True,
+        {"app": {"tar_get": "web/server"}},
+    ),
+    (
+        {"a.p.p": {"t?r/get": "?web/server"}},
+        True,
+        {"a_p_p": {"t_r_get": "?web/server"}},
+    ),
+    (
+        {"key1": {"key2": {"key?/+12-*": "?web/server"}}},
+        True,
+        {"key1": {"key2": {"key_12_": "?web/server"}}},
+    ),
+    (
+        {"key1": {"key?2": "abc", "key_2": "345"}},
+        False,
+        {"key1": {"key_2": "345"}},
+    ),
+    (
+        {"key1": {"key_2": "abc", "key?2": "345"}},
+        True,
+        {"key1": {"key_2": "345"}},
+    ),
+    (
+        {"key1": [{"key/2": "abc"}, {"key?2": "345"}]},
+        True,
+        {"key1": [{"key_2": "abc"}, {"key_2": "345"}]},
+    ),
+    (
+        {"key1": [{"key/2": "abc"}, 5]},
+        True,
+        {"key1": [{"key_2": "abc"}, 5]},
+    ),
+]
+
+
+@pytest.mark.parametrize("event, overwrite, updated_event", TEST_DATA_1)
+def test_normalize_keys(event, overwrite, updated_event):
+    data = normalize_main(event, overwrite)
+    assert data == updated_event


### PR DESCRIPTION
The keys in the event payload should follow the convention of of an ansible variable name. A key name can only consist of alpha numeric and under score charachters. All non conforming charachters are converted to _.

https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#creating-valid-variable-names

This is a generic form of the dashes_to_underscore filter, which only translates dashes. This filter translates all non conforming characters