### PR TITLE
Fix Webhook source without token

### DIFF
--- a/extensions/eda/plugins/event_source/webhook.py
+++ b/extensions/eda/plugins/event_source/webhook.py
@@ -30,7 +30,7 @@ async def webhook(request: web.Request):
     payload = await request.json()
     endpoint = request.match_info["endpoint"]
     headers = dict(request.headers)
-    headers.pop("Authorization")
+    headers.pop("Authorization", None)
     data = {
         "payload": payload,
         "meta": {"endpoint": endpoint, "headers": headers},


### PR DESCRIPTION
Fixes Webhook event source in case the token isn't used/set.
Otherwise it raises `KeyError`.