### PR TITLE
Include periodic jobs execution for the collection

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,11 +1,15 @@
-name: Integration tests
-
+name: Run integration tests
 on:
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
+  # Run the integration tests every 8 hours.
+  # This will help to identify faster if
+  # there is a CI failure related to a
+  # change in any dependency.
+  schedule:
+    - cron: '0 */8 * * *'
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,16 @@
 ---
-on: [push, pull_request]
-name: Linters
+name: Run linters
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Run the linters tests every 8 hours.
+  # This will help to identify faster if
+  # there is a CI failure related to a
+  # change in any dependency.
+  schedule:
+    - cron: '0 */8 * * *'
 jobs:
   black:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,15 @@
 name: Run Ansible tests
-
 on:
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
+  # Run the unit tests every 8 hours.
+  # This will help to identify faster if
+  # there is a CI failure related to a
+  # change in any dependency.
+  schedule:
+    - cron: '0 */8 * * *'
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,6 +1,16 @@
 ---
-on: [push, pull_request]
 name: Tox
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Run the tox tests every 8 hours.
+  # This will help to identify faster if
+  # there is a CI failure related to a
+  # change in any dependency.
+  schedule:
+    - cron: '0 */8 * * *'
 jobs:
   tox:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This collection contains event source plugins, event filters and example rulebooks to be used with [ansible-rulebook](https://ansible-rulebook.readthedocs.io/en/stable/).
 
+<p style="text-align: center" align="center">
+    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=integration-tests"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/integration-tests.yml/badge.svg?event=schedule"/> </a>
+    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=linters"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/linters.yml/badge.svg?event=schedule"/> </a>
+    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=tests"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/tests.yml/badge.svg?event=schedule"/> </a>
+    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=tox"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/tox.yml/badge.svg?event=schedule"/> </a>
+</p>
+
 ## Install
 
 Install the ansible.eda collection with the Ansible Galaxy CLI:


### PR DESCRIPTION
This collection is not pinning any of the requirements versions, if there is an update i.e. in the pytest or ansible lint packages the linters, integration or unit tests might start to fail for unrelated reasons.
This commit add periodic executions in the GH actions workflows and includes a badge per job in the README.md file.