### PR TITLE
Require Ansible version >=2.9.10

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.8"
+requires_ansible: ">=2.9.10"


### PR DESCRIPTION
The meta runtime version is set to a very old version and needs to be updated