### PR TITLE
False positive output in tox linter checks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,7 @@
 name: Run integration tests
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
   # Run the integration tests every 8 hours.
   # This will help to identify faster if
   # there is a CI failure related to a

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,9 +2,7 @@
 name: Run linters
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
   # Run the linters tests every 8 hours.
   # This will help to identify faster if
   # there is a CI failure related to a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,7 @@
 name: Run Ansible tests
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
   # Run the unit tests every 8 hours.
   # This will help to identify faster if
   # there is a CI failure related to a

--- a/.github/workflows/tox.ini
+++ b/.github/workflows/tox.ini
@@ -12,13 +12,11 @@ requires =
 
 [testenv:ruff]
 deps = ruff
-commands = ruff check --select ALL --ignore INP001 -q {posargs}/extensions/eda/plugins
-
+commands = ruff check --select ALL --ignore INP001 --extend-exclude test,tests -v {posargs}
 
 [testenv:darglint]
 deps = darglint
-commands = darglint -s numpy -z full {posargs}/extensions/eda/plugins
-
+commands = darglint -s numpy -z full {posargs}
 
 # If you dont have any event_source or event_filter plugins, remove the corresponding testenv
 [testenv:pylint-event-source]

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,10 +1,8 @@
 ---
-name: Tox
+name: Run Tox linters checks
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
   # Run the tox tests every 8 hours.
   # This will help to identify faster if
   # there is a CI failure related to a
@@ -21,4 +19,4 @@ jobs:
       - name: Move to tox conf file and run tox
         run: | 
           cd .github/workflows
-          python -m tox -- ../..
+          python3 -m tox -- ../..


### PR DESCRIPTION
This commit:
- Makes easier to test individually each commit by allowing to run the GitHub actions on each fork push and pull request.
- Remove the appended path in the ruff tox check that breaks it to parse recursivelly all the python code.

TODO: This should be applied to all the other tox check to make them show correctly all the linters errors.

Closes: #145