### PR TITLE
Failing tox test - use noqa perf203

### DIFF
--- a/extensions/eda/plugins/event_source/aws_sqs_queue.py
+++ b/extensions/eda/plugins/event_source/aws_sqs_queue.py
@@ -67,7 +67,7 @@ async def main(queue: asyncio.Queue, args: dict[str, Any]) -> None:
                     meta = {"MessageId": msg["MessageId"]}
                     try:
                         msg_body = json.loads(msg["Body"])
-                    except json.JSONDecodeError:
+                    except json.JSONDecodeError:  # noqa: perf203
                         msg_body = msg["Body"]
 
                     await queue.put({"body": msg_body, "meta": meta})

--- a/extensions/eda/plugins/event_source/url_check.py
+++ b/extensions/eda/plugins/event_source/url_check.py
@@ -51,7 +51,7 @@ async def main(queue: asyncio.Queue, args: dict[str, Any]) -> None:
                             },
                         )
 
-        except aiohttp.ClientError as e:
+        except aiohttp.ClientError as e:  # noqa: perf203
             client_error = str(e)
             await queue.put(
                 {


### PR DESCRIPTION
This PR fixes failing `tox` action (https://github.com/ansible/event-driven-ansible/actions/runs/5461650644/jobs/9939922571?pr=139#step:4:15) by setting `noqa: perf203`, the `try-except` structure makes sense in these cases.