### PR TITLE
Update link to latest plugin URL instead of outdated

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -28,4 +28,4 @@ Here is an example directory of the majority of plugins currently supported by A
     └── vars
 ```
 
-A full list of plugin types can be found at [Working With Plugins](https://docs.ansible.com/ansible-core/2.12/plugins/plugins.html).
+A full list of plugin types can be found at [Working With Plugins](https://docs.ansible.com/ansible/latest/plugins/plugins.html).


### PR DESCRIPTION
Updated unmaintained URL:
From:
https://docs.ansible.com/ansible-core/2.12/plugins/plugins.html
To:
https://docs.ansible.com/ansible/latest/plugins/plugins.html