### PR TITLE
Fix aws_cloudtrail even duplication bug

### DIFF
--- a/extensions/eda/plugins/event_source/aws_cloudtrail.py
+++ b/extensions/eda/plugins/event_source/aws_cloudtrail.py
@@ -91,9 +91,9 @@ async def main(queue: asyncio.Queue, args: dict[str, Any]) -> None:
         event_time = None
         event_ids = []
         while True:
-            events = await _get_cloudtrail_events(client, params)
             if event_time is not None:
                 params["StartTime"] = event_time
+            events = await _get_cloudtrail_events(client, params)
 
             events, c_event_time, c_event_ids = _get_events(events, event_ids)
             for event in events:


### PR DESCRIPTION
Fixes a minor bug in the aws_cloudtrail event_source plugin where cloudtrail events were retrieved and added to queue twice. The boto3 client `StartTime` parameter needs to be set to the last retrieved event time before the next batch of events is retrieved instead of after.