### PR TITLE
feat: Add Kafka SASL_SSL authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ tests/output
 .pytest_cache/
 .tox
 .ruff*
+tests/integration/event_source_kafka/*.crt
+tests/integration/event_source_kafka/*.key
+tests/integration/event_source_kafka/*.csr
+tests/integration/event_source_kafka/*.jks
 
 # Ide's
 .vscode

--- a/extensions/eda/plugins/event_source/kafka.py
+++ b/extensions/eda/plugins/event_source/kafka.py
@@ -14,11 +14,21 @@ Arguments:
     keyfile:   The optional client key file path containing the client private key
     password:  The optional password to be used when loading the certificate chain
     check_hostname:  Enable SSL hostname verification. [True (default), False]
+    verify_mode: Whether to try to verify other peers' certificates and how to
+               behave if verification fails. [CERT_NONE, CERT_OPTIONAL,
+               CERT_REQUIRED (default)]
     encoding:  Message encoding scheme. Default to utf-8
     topic:     The kafka topic
     group_id:  A kafka group id
     offset:    Where to automatically reset the offset. [latest, earliest]
                Default to latest
+    security_protocol: Protocol used to communicate with brokers. [PLAINTEXT, SSL,
+               SASL_PLAINTEXT, SASL_SSL]. Default to PLAINTEXT
+    sasl_mechanism: Authentication mechanism when security_protocol is configured.
+               [PLAIN, GSSAPI, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER].
+               Default to PLAIN.
+    sasl_plain_username: Username for SASL PLAIN authentication
+    sasl_plain_password: Password for SASL PLAIN authentication
 
 
 
@@ -27,6 +37,7 @@ Arguments:
 import asyncio
 import json
 import logging
+from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
 from typing import Any
 
 from aiokafka import AIOKafkaConsumer
@@ -48,22 +59,38 @@ async def main(  # pylint: disable=R0914
     keyfile = args.get("keyfile")
     password = args.get("password")
     check_hostname = args.get("check_hostname", True)
+    verify_mode = args.get("verify_mode", "CERT_REQUIRED")
     group_id = args.get("group_id", None)
     offset = args.get("offset", "latest")
     encoding = args.get("encoding", "utf-8")
+    security_protocol = args.get("security_protocol", "PLAINTEXT")
 
     if offset not in ("latest", "earliest"):
         msg = f"Invalid offset option: {offset}"
         raise ValueError(msg)
 
-    if cafile:
-        context = create_ssl_context(
+    verify_modes = {
+        "CERT_NONE": CERT_NONE,
+        "CERT_OPTIONAL": CERT_OPTIONAL,
+        "CERT_REQUIRED": CERT_REQUIRED,
+    }
+    try:
+        verify_mode = verify_modes[verify_mode]
+    except KeyError as exc:
+        msg = f"Invalid verify_mode option: {verify_mode}"
+        raise ValueError(msg) from exc
+
+    ssl_context = None
+    if cafile or security_protocol.endswith("SSL"):
+        security_protocol = security_protocol.replace("PLAINTEXT", "SSL")
+        ssl_context = create_ssl_context(
             cafile=cafile,
             certfile=certfile,
             keyfile=keyfile,
             password=password,
         )
-        context.check_hostname = check_hostname
+        ssl_context.check_hostname = check_hostname
+        ssl_context.verify_mode = verify_mode
 
     kafka_consumer = AIOKafkaConsumer(
         topic,
@@ -72,8 +99,11 @@ async def main(  # pylint: disable=R0914
         enable_auto_commit=True,
         max_poll_records=1,
         auto_offset_reset=offset,
-        security_protocol="SSL" if cafile else "PLAINTEXT",
-        ssl_context=context if cafile else None,
+        security_protocol=security_protocol,
+        ssl_context=ssl_context,
+        sasl_mechanism=args.get("sasl_mechanism", "PLAIN"),
+        sasl_plain_username=args.get("sasl_plain_username"),
+        sasl_plain_password=args.get("sasl_plain_password"),
     )
 
     await kafka_consumer.start()

--- a/tests/integration/event_source_kafka/ansible
+++ b/tests/integration/event_source_kafka/ansible
@@ -1,0 +1,1 @@
+ansible

--- a/tests/integration/event_source_kafka/broker_jaas.conf
+++ b/tests/integration/event_source_kafka/broker_jaas.conf
@@ -1,0 +1,7 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="test"
+  password="test"
+  user_test="test";
+};
+Client{};

--- a/tests/integration/event_source_kafka/certs-clean.sh
+++ b/tests/integration/event_source_kafka/certs-clean.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+DIR=$(dirname "${BASH_SOURCE[0]}")
+rm -f "${DIR}/snakeoil-ca.key" \
+      "${DIR}/snakeoil-ca.crt" \
+      "${DIR}/broker.csr" \
+      "${DIR}/broker-ca-signed.crt" \
+      "${DIR}/kafka.broker.keystore.jks" \
+      "${DIR}/kafka.broker.truststore.jks"

--- a/tests/integration/event_source_kafka/certs-create.sh
+++ b/tests/integration/event_source_kafka/certs-create.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Generate self-signed certificate for Kafka broker
+# Greatly inspired by https://github.com/ansibleinc/cp-demo/blob/master/scripts/security/certs-create-per-user.sh
+set -e
+
+CA_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+# Generate CA
+openssl req -new -x509 -keyout snakeoil-ca.key -out snakeoil-ca.crt -days 365 -subj '/CN=snakeoil.ansible.com/OU=TEST/O=ANSIBLE/L=Boston/ST=MA/C=US' -passin pass:ansible -passout pass:ansible
+
+# Create broker keystore
+keytool -genkey -noprompt \
+    -alias broker \
+    -dname "CN=broker,OU=TEST,O=ANSIBLE,L=Boston,S=MA,C=US" \
+    -ext "SAN=dns:broker,dns:localhost" \
+    -keystore kafka.broker.keystore.jks \
+    -keyalg RSA \
+    -storepass ansible \
+    -keypass ansible \
+    -storetype pkcs12
+
+# Create broker CSR
+keytool -keystore kafka.broker.keystore.jks -alias broker -certreq -file broker.csr -storepass ansible -keypass ansible -ext "SAN=dns:broker,dns:localhost"
+
+# Sign the host certificate with the certificate authority (CA)
+# Set a random serial number (avoid problems from using '-CAcreateserial' when parallelizing certificate generation)
+CERT_SERIAL=$(awk -v seed="$RANDOM" 'BEGIN { srand(seed); printf("0x%.4x%.4x%.4x%.4x\n", rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1, rand()*65535 + 1) }')
+openssl x509 -req -CA "${CA_PATH}/snakeoil-ca.crt" -CAkey "${CA_PATH}/snakeoil-ca.key" -in broker.csr -out broker-ca-signed.crt -sha256 -days 365 -set_serial "${CERT_SERIAL}" -passin pass:ansible -extensions v3_req -extfile <(cat <<EOF
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = broker
+[v3_req]
+extendedKeyUsage = serverAuth, clientAuth
+EOF
+)
+
+# Sign and import the CA cert into the keystore
+keytool -noprompt -keystore kafka.broker.keystore.jks -alias snakeoil-caroot -import -file "${CA_PATH}/snakeoil-ca.crt" -storepass ansible -keypass ansible
+
+# Sign and import the host certificate into the keystore
+keytool -noprompt -keystore kafka.broker.keystore.jks -alias broker -import -file broker-ca-signed.crt -storepass ansible -keypass ansible -ext "SAN=dns:broker,dns:localhost"
+
+# Create truststore and import the CA cert
+keytool -noprompt -keystore kafka.broker.truststore.jks -alias snakeoil-caroot -import -file "${CA_PATH}/snakeoil-ca.crt" -storepass ansible -keypass ansible

--- a/tests/integration/event_source_kafka/docker-compose.yml
+++ b/tests/integration/event_source_kafka/docker-compose.yml
@@ -7,26 +7,43 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_SASL_ENABLED: "false"
 
   broker:
     image: docker.io/confluentinc/cp-kafka:7.0.1
     ports:
-      - "9092:9092"
+      - "9092:9092"  # PLAINTEXT
+      - "9093:9093"  # SSL
+      - "9094:9094"  # SASL_PLAINTEXT
+      - "9095:9095"  # SASL_SSL
     depends_on:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
+      ZOOKEEPER_SASL_ENABLED: "false"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092,SSL://localhost:9093,SASL_PLAINTEXT://localhost:9094,SASL_SSL://localhost:9095
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/broker_jaas.conf"
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SSL_KEYSTORE_FILENAME: kafka.broker.keystore.jks
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: ansible
+      KAFKA_SSL_KEY_CREDENTIALS: ansible
+      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.broker.trustore.jks
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: ansible
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
     healthcheck:
-      test: nc -vz localhost 9092
+      test: nc -vz localhost 9092 && nc -vz localhost 9093 && nc -vz localhost 9094 && nc -vz localhost 9095
       interval: 5s
       timeout: 3s
       retries: 6
+    volumes:
+      - ./broker_jaas.conf:/etc/kafka/broker_jaas.conf
+      - ./kafka.broker.truststore.jks:/etc/kafka/secrets/kafka.broker.trustore.jks
+      - ./kafka.broker.keystore.jks:/etc/kafka/secrets/kafka.broker.keystore.jks
+      - ./ansible:/etc/kafka/secrets/ansible
 
   wait_for:
     image: docker.io/confluentinc/cp-kafka:7.0.1

--- a/tests/integration/event_source_kafka/test_kafka_rules_plaintext.yml
+++ b/tests/integration/event_source_kafka/test_kafka_rules_plaintext.yml
@@ -1,18 +1,18 @@
-- name: test kafka source plugin
+- name: test kafka source plugin with plaintext security protocol
   hosts: localhost
   sources:
     - ansible.eda.kafka:
-        topic: kafka-events
+        topic: kafka-events-plaintext
         host: localhost
         port: 9092
         offset: earliest
         encoding: ascii
   rules:
     - name: match kafka event
-      condition: event.body.name == "some kafka event"
+      condition: event.body.name == "Produced for PLAINTEXT consumers"
       action:
         debug:
-          msg: "Rule fired successfully"
+          msg: "Rule fired successfully for PLAINTEXT consumers"
 
     - name: stop
       condition: event.body == "stop"

--- a/tests/integration/event_source_kafka/test_kafka_rules_sasl_plaintext.yml
+++ b/tests/integration/event_source_kafka/test_kafka_rules_sasl_plaintext.yml
@@ -1,0 +1,24 @@
+- name: test kafka source plugin with sasl_plaintext security protocol
+  hosts: localhost
+  sources:
+    - ansible.eda.kafka:
+        topic: kafka-events-sasl-plaintext
+        host: localhost
+        port: 9094
+        offset: earliest
+        encoding: ascii
+        security_protocol: SASL_PLAINTEXT
+        sasl_mechanism: PLAIN
+        sasl_plain_username: test
+        sasl_plain_password: test
+  rules:
+    - name: match kafka event
+      condition: event.body.name == "Produced for SASL_PLAINTEXT consumers"
+      action:
+        debug:
+          msg: "Rule fired successfully for SASL_PLAINTEXT consumers"
+
+    - name: stop
+      condition: event.body == "stop"
+      action:
+        shutdown:

--- a/tests/integration/event_source_kafka/test_kafka_rules_sasl_ssl.yml
+++ b/tests/integration/event_source_kafka/test_kafka_rules_sasl_ssl.yml
@@ -1,0 +1,26 @@
+- name: test kafka source plugin with sasl_ssl security protocol
+  hosts: localhost
+  sources:
+    - ansible.eda.kafka:
+        topic: kafka-events-sasl-ssl
+        host: localhost
+        port: 9095
+        offset: earliest
+        encoding: ascii
+        security_protocol: SASL_SSL
+        sasl_mechanism: PLAIN
+        sasl_plain_username: test
+        sasl_plain_password: test
+        check_hostname: false
+        verify_mode: CERT_NONE
+  rules:
+    - name: match kafka event
+      condition: event.body.name == "Produced for SASL_SSL consumers"
+      action:
+        debug:
+          msg: "Rule fired successfully for SASL_SSL consumers"
+
+    - name: stop
+      condition: event.body == "stop"
+      action:
+        shutdown:

--- a/tests/integration/event_source_kafka/test_kafka_rules_ssl.yml
+++ b/tests/integration/event_source_kafka/test_kafka_rules_ssl.yml
@@ -1,0 +1,23 @@
+- name: test kafka source plugin with ssl security protocol
+  hosts: localhost
+  sources:
+    - ansible.eda.kafka:
+        topic: kafka-events-ssl
+        host: localhost
+        port: 9093
+        offset: earliest
+        encoding: ascii
+        security_protocol: SSL
+        check_hostname: false
+        verify_mode: CERT_NONE
+  rules:
+    - name: match kafka event
+      condition: event.body.name == "Produced for SSL consumers"
+      action:
+        debug:
+          msg: "Rule fired successfully for SSL consumers"
+
+    - name: stop
+      condition: event.body == "stop"
+      action:
+        shutdown:

--- a/tests/integration/event_source_kafka/test_kafka_source.py
+++ b/tests/integration/event_source_kafka/test_kafka_source.py
@@ -8,7 +8,16 @@ from kafka import KafkaProducer
 from ..utils import TESTS_PATH, CLIRunner
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def kafka_certs():
+    cwd = os.path.join(TESTS_PATH, "event_source_kafka")
+    print(cwd)
+    result = subprocess.run([os.path.join(cwd, "certs-create.sh")], cwd=cwd, check=True)
+    yield result
+    subprocess.run([os.path.join(cwd, "certs-clean.sh")], cwd=cwd, check=True)
+
+
+@pytest.fixture(scope="session")
 def kafka_broker():
     cwd = os.path.join(TESTS_PATH, "event_source_kafka")
     print(cwd)
@@ -17,22 +26,78 @@ def kafka_broker():
     subprocess.run(["docker-compose", "down", "-v"], cwd=cwd, check=True)
 
 
-@pytest.fixture()
-def kafka_producer(kafka_broker):
+@pytest.fixture(scope="session")
+def kafka_producer(kafka_certs, kafka_broker):
     return KafkaProducer(bootstrap_servers="localhost:9092")
 
 
-def test_kafka_source_sanity(kafka_producer: KafkaProducer):
-    ruleset = os.path.join(TESTS_PATH, "event_source_kafka", "test_kafka_rules.yml")
+def test_kafka_source_plaintext(kafka_certs, kafka_broker, kafka_producer):
+    ruleset = os.path.join(
+        TESTS_PATH, "event_source_kafka", "test_kafka_rules_plaintext.yml"
+    )
 
     msgs = [
-        json.dumps({"name": "some kafka event"}).encode("ascii"),
+        json.dumps({"name": "Produced for PLAINTEXT consumers"}).encode("ascii"),
         "stop".encode("ascii"),
     ]
 
     for msg in msgs:
-        kafka_producer.send(topic="kafka-events", value=msg)
+        kafka_producer.send(topic="kafka-events-plaintext", value=msg)
 
     result = CLIRunner(rules=ruleset).run()
 
-    assert "Rule fired successfully" in result.stdout.decode()
+    assert "Rule fired successfully for PLAINTEXT consumers" in result.stdout.decode()
+
+
+def test_kafka_source_ssl(kafka_certs, kafka_broker, kafka_producer):
+    ruleset = os.path.join(TESTS_PATH, "event_source_kafka", "test_kafka_rules_ssl.yml")
+
+    msgs = [
+        json.dumps({"name": "Produced for SSL consumers"}).encode("ascii"),
+        "stop".encode("ascii"),
+    ]
+
+    for msg in msgs:
+        kafka_producer.send(topic="kafka-events-ssl", value=msg)
+
+    result = CLIRunner(rules=ruleset).run()
+
+    assert "Rule fired successfully for SSL consumers" in result.stdout.decode()
+
+
+def test_kafka_source_sasl_plaintext(kafka_certs, kafka_broker, kafka_producer):
+    ruleset = os.path.join(
+        TESTS_PATH, "event_source_kafka", "test_kafka_rules_sasl_plaintext.yml"
+    )
+
+    msgs = [
+        json.dumps({"name": "Produced for SASL_PLAINTEXT consumers"}).encode("ascii"),
+        "stop".encode("ascii"),
+    ]
+
+    for msg in msgs:
+        kafka_producer.send(topic="kafka-events-sasl-plaintext", value=msg)
+
+    result = CLIRunner(rules=ruleset).run()
+
+    assert (
+        "Rule fired successfully for SASL_PLAINTEXT consumers" in result.stdout.decode()
+    )
+
+
+def test_kafka_source_sasl_ssl(kafka_certs, kafka_broker, kafka_producer):
+    ruleset = os.path.join(
+        TESTS_PATH, "event_source_kafka", "test_kafka_rules_sasl_ssl.yml"
+    )
+
+    msgs = [
+        json.dumps({"name": "Produced for SASL_SSL consumers"}).encode("ascii"),
+        "stop".encode("ascii"),
+    ]
+
+    for msg in msgs:
+        kafka_producer.send(topic="kafka-events-sasl-ssl", value=msg)
+
+    result = CLIRunner(rules=ruleset).run()
+
+    assert "Rule fired successfully for SASL_SSL consumers" in result.stdout.decode()


### PR DESCRIPTION
Add `security_protocol`, `sasl_mechanism`, `sasl_plain_username` and `sasl_plain_password` arguments like aiokafka.AIOKafkaConsumer client.

https://aiokafka.readthedocs.io/en/stable/consumer.html