### PR TITLE
ci: remove parallel execution of unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,5 @@ jobs:
         working-directory: ansible_collections/ansible/eda
 
       - name: Run unit tests
-        run: ansible-test units --venv
+        run: ansible-test units --venv -v --num-workers 1
         working-directory: ansible_collections/ansible/eda


### PR DESCRIPTION
Unit tests fail due to collisions on the same port. Disable parallel execution. 
Example: https://github.com/Alex-Izquierdo/event-driven-ansible/actions/runs/6787231834/job/18449579146