### PR TITLE
Remove duplicate dpath from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ watchdog
 systemd-python
 dpath
 pyyaml
-dpath


### PR DESCRIPTION
This was added in a31b892 but was already defined in the requirements.txt file.