### PR TITLE
Integration tests: add kafka-python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-azure-servicebus
 aiobotocore
 aiohttp
 aiokafka
-watchdog
-systemd-python
+azure-servicebus
 dpath
+kafka-python
 pyyaml
+systemd-python
+watchdog


### PR DESCRIPTION
This PR:
- adds the `kafka-python` dependency
- sorts the requirements

https://github.com/konstruktoid/event-driven-ansible/actions/runs/7097863427/job/19318725270:
```console
tests/integration/event_source_kafka/test_kafka_source.py:6: in <module>
    from kafka import KafkaProducer
E   ModuleNotFoundError: No module named 'kafka'
=========================== short test summary info ============================
ERROR tests/integration/event_source_kafka/test_kafka_source.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.29s ===============================
Error: Process completed with exit code 2.
```