### PR TITLE
chore: systemd-python not available on MacOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ azure-servicebus
 dpath
 kafka-python
 pyyaml
-systemd-python
+systemd-python; sys_platform != 'darwin'
 watchdog


### PR DESCRIPTION
When running tests the systemd-python can't be installed and the tests fail, making the package optional for MacOS