### PR TITLE
Fix example in filter insert_hosts_to_meta

### DIFF
--- a/extensions/eda/plugins/event_filter/insert_hosts_to_meta.py
+++ b/extensions/eda/plugins/event_filter/insert_hosts_to_meta.py
@@ -17,10 +17,11 @@ Arguments:
 
 Example:
 -------
-    - ansible.eda.insert_hosts_to_meta
-      host_path: app.target
-      path_separator: .
-      host_separator: ;
+    filters:
+      - ansible.eda.insert_hosts_to_meta:
+          host_path: "app.target"
+          path_separator: "."
+          host_separator: ";"
 
 """
 


### PR DESCRIPTION
Indentation was incorrect and a colon was missing. I also think that quotes are recommended for values.
And adding the `filters` makes the context a bit clearer.