### PR TITLE
Fix spacing as expected by black

### DIFF
--- a/extensions/eda/plugins/event_source/tick.py
+++ b/extensions/eda/plugins/event_source/tick.py
@@ -13,6 +13,7 @@ Example:
         delay: 5
 
 """
+
 import asyncio
 import itertools
 from typing import Any

--- a/tests/unit/event_source/test_generic.py
+++ b/tests/unit/event_source/test_generic.py
@@ -1,4 +1,5 @@
 """ Tests for generic source plugin """
+
 import asyncio
 
 import pytest


### PR DESCRIPTION
black 24.1.0 has introduced at least one new spacing rule and the pipeline errors were driving me crazy so here a fix.