### PR TITLE
ci: fix failing ci due to pytest bug

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -5,6 +5,7 @@ asyncio
 asyncmock
 azure-servicebus
 dpath
+pytest<8  # https://github.com/ansible/ansible/issues/82713
 pytest-asyncio
 psycopg
 xxhash


### PR DESCRIPTION
A bug has been introduced in pytest v8 that causes the CI to fail. Pinning ptest<8 for now. Related ansible-test bug report: https://github.com/ansible/ansible/issues/82713