### PR TITLE
chore: fixed examples to use vars instead of jinja

### DIFF
--- a/extensions/eda/rulebooks/git-hook-deploy-rules.yml
+++ b/extensions/eda/rulebooks/git-hook-deploy-rules.yml
@@ -6,7 +6,7 @@
         port: 5001
   rules:
     - name: run tests 1
-      condition: event.payload.repo == "{{repo}}"
+      condition: event.payload.repo == vars.repo
       action:
         run_playbook:
           name: ansible.eda.continuous_integration

--- a/extensions/eda/rulebooks/git-hook-test-rules.yml
+++ b/extensions/eda/rulebooks/git-hook-test-rules.yml
@@ -5,7 +5,7 @@
     - ansible.eda.webhook:
   rules:
     - name: run tests 1
-      condition: event.payload.src_path == "{{src_path}}"
+      condition: event.payload.src_path == vars.src_path
       action:
         run_playbook:
           name: ansible.eda.run_pytest

--- a/extensions/eda/rulebooks/github-ci-cd-rules.yml
+++ b/extensions/eda/rulebooks/github-ci-cd-rules.yml
@@ -41,7 +41,7 @@
             pr: "{{event.payload.number}}"
             sha: "{{event.payload.after}}"
     - name: run tests
-      condition: event.repository_name == "{{repo_name}}" and event.pr is defined
+      condition: event.repository_name == vars.repo_name and event.pr is defined
       action:
         run_playbook:
           name: ansible.eda.continuous_integration


### PR DESCRIPTION
In a rulebook when we define a condition we cannot use Jinja substitution, instead the vars namespace should be used to get values from the passed in extra vars.

https://issues.redhat.com/browse/AAP-20843