### PR TITLE
chore: add changelog, fix lint issues and bump 1.4.7

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,7 @@
+warn_list:
+  - experimental  # all rules tagged as experimental
+exclude_paths:
+  - continuous_integration.yml
+  - run_pytest.yml
+  - start_app.yml
+  - roles/test_role/

--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,2 +1,0 @@
-warn_list:
-  - experimental  # all rules tagged as experimental

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# CHANGELOG
+
+## 1.4.7
+
+### Features
+
+* feat: add raise_error and log_error option to insert_hosts_to_meta filter
+* feat: enable webhook mTLS support
+
+### Fixes
+
+* fixed examples to use vars instead of jinja

--- a/extensions/eda/rulebooks/github-ci-cd-rules.yml
+++ b/extensions/eda/rulebooks/github-ci-cd-rules.yml
@@ -14,7 +14,7 @@
       condition: event.meta.headers.X_Github_Event == "pull_request" and event.payload.action == "opened"
       action:
         post_event:
-          fact:
+          event:
             repository_name: "{{event.payload.repository.full_name}}"
             repo: "{{event.payload.pull_request.head.repo.clone_url}}"
             ref: "{{event.payload.pull_request.head.ref}}"
@@ -24,7 +24,7 @@
       condition: event.meta.headers.X_Github_Event == "pull_request" and event.payload.action == "reopened"
       action:
         post_event:
-          fact:
+          event:
             repository_name: "{{event.payload.repository.full_name}}"
             repo: "{{event.payload.pull_request.head.repo.clone_url}}"
             ref: "{{event.payload.pull_request.head.ref}}"
@@ -34,7 +34,7 @@
       condition: event.meta.headers.X_Github_Event == "pull_request" and event.payload.action == "synchronize"
       action:
         post_event:
-          fact:
+          event:
             repository_name: "{{event.payload.repository.full_name}}"
             repo: "{{event.payload.repository.clone_url}}"
             ref: "{{event.payload.pull_request.head.ref}}"
@@ -52,7 +52,7 @@
         print_event:
           var_root: output
     - name: debug
-      enabled: False
+      enabled: false
       condition: event.payload is defined
       action:
         debug:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ansible
 name: eda
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.4.6
+version: 1.4.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/playbooks/hello.yml
+++ b/playbooks/hello.yml
@@ -1,8 +1,8 @@
 ---
-- name: hello
+- name: Hello
   hosts: localhost
   gather_facts: false
   tasks:
-    - debug:
+    - name: Print hello
+      ansible.builtin.debug:
         msg: hello
-...

--- a/plugins/modules/upcase.py
+++ b/plugins/modules/upcase.py
@@ -46,7 +46,6 @@ EXAMPLES = r"""
 - name: Test with a fail message
   ansible.eda.upcase:
     name: fail
-
 """
 
 RETURN = r"""


### PR DESCRIPTION
Some minor changes required for the certification. 
- Adds a changelog
- Exclude some sample content for ansible-lint
- Some minor fixes for lint warnings. 
- Bump to 1.4.7