### PR TITLE
docs: added a simple rulebook for demo purposes

### DIFF
--- a/extensions/eda/rulebooks/demo_rulebook.yml
+++ b/extensions/eda/rulebooks/demo_rulebook.yml
@@ -1,0 +1,25 @@
+---
+# This rulebook is for demo purposes only
+# Typically the events come from an external source 
+# and you might have to configure the external source
+# and have it generate events on demand.
+# In this simple rulebook the events to be generated
+# is directly defined in the source definition using
+# the ansible.eda.generic source plugin which defines
+# a collection of events under the payload key.
+#
+- name: Simple Rulebook for Demo
+  hosts: all
+  sources:
+    - name: Demo Source
+      ansible.eda.generic:
+        payload:
+          - msg: "Welcome"
+          - msg: "Adios"
+  rules:
+    - name: Say Hello
+      condition: event.msg == "Welcome"
+      action:
+        debug:
+          msg: "Hello from EDA"
+...


### PR DESCRIPTION
We need a simple rulebook for Quick Startup guide that does not connect to the controller. The other rulebook we have requires a controller.