### PR TITLE
feat: generic source supports events in yaml file

### DIFF
--- a/extensions/eda/plugins/event_source/generic.py
+++ b/extensions/eda/plugins/event_source/generic.py
@@ -4,6 +4,7 @@ The event data to insert into the queue is specified in the required
 parameter payload and is an array of events.
 
 Optional Parameters:
+payload_file A yaml with an array of events can be used instead of payload
 randomize    True|False Randomize the events in the payload, default False
 display      True|False Display the event data in stdout, default False
 timestamp    True|False Add an event timestamp, default False
@@ -56,7 +57,10 @@ import random
 import time
 from dataclasses import dataclass, fields
 from datetime import datetime
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 
 @dataclass
@@ -67,6 +71,7 @@ class Args:
     final_payload: Any = None
     display: bool = False
     create_index: str = ""
+    payload_file: str = ""
 
 
 @dataclass
@@ -99,6 +104,10 @@ class Generic:
         """Insert event data into the queue."""
         self.queue = queue
         field_names = [f.name for f in fields(Args)]
+
+        if "payload_file" in args:
+            args["payload"] = ""
+
         self.my_args = Args(**{k: v for k, v in args.items() if k in field_names})
         field_names = [f.name for f in fields(ControlArgs)]
         self.control_args = ControlArgs(
@@ -123,6 +132,8 @@ class Generic:
         ]:
             msg = "time_format must be one of local, iso8601, epoch"
             raise ValueError(msg)
+
+        await self._load_payload_from_file()
 
         if not isinstance(self.my_args.payload, list):
             self.my_args.payload = [self.my_args.payload]
@@ -160,6 +171,20 @@ class Generic:
         if self.my_args.display:
             print(data)  # noqa: T201
         await self.queue.put(data)
+
+    async def _load_payload_from_file(self: Generic) -> None:
+        if not self.my_args.payload_file:
+            return
+        path = Path(self.my_args.payload_file)
+        if not path.is_file():
+            msg = f"File {self.my_args.payload_file} not found"
+            raise ValueError(msg)
+        with path.open(mode="r", encoding="utf-8") as file:
+            try:
+                self.my_args.payload = yaml.safe_load(file)
+            except yaml.YAMLError as exc:
+                msg = f"File {self.my_args.payload_file} parsing error {exc}"
+                raise ValueError(msg) from exc
 
     def _create_data(
         self: Generic,


### PR DESCRIPTION
This feature allows you to store an array of events in a yaml file and load the events from the yaml file when the rulebook is running. The new argument is called **payload_file**