### PR TITLE
chore: enable release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+---
+# see https://github.com/ansible/team-devtools
+_extends: ansible/team-devtools

--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -1,0 +1,11 @@
+---
+# See https://github.com/ansible/devtools/blob/main/.github/workflows/ack.yml
+name: ack
+"on":
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  ack:
+    uses: ansible/team-devtools/.github/workflows/ack.yml@main
+    secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,13 @@
+---
+# See https://github.com/ansible/devtools/blob/main/.github/workflows/push.yml
+name: push
+"on":
+  push:
+    branches:
+      - main
+      - "releases/**"
+      - "stable/**"
+
+jobs:
+  ack:
+    uses: ansible/team-devtools/.github/workflows/push.yml@main


### PR DESCRIPTION
This change will make use of release drafter for drafting changelog updates on https://github.com/ansible/event-driven-ansible/releases so it would be much easier to know what was merged and if a release is needed or not.
