### PR TITLE
Replace docker-compose with podman-compose

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 */8 * * *'
 jobs:
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
       - name: Install package dependencies
         run: |
           sudo apt-get update
-          sudo apt-get --assume-yes --no-install-recommends install libsystemd0 libsystemd-dev pkg-config
+          sudo apt-get --assume-yes --no-install-recommends install libsystemd0 libsystemd-dev pkg-config podman-compose
 
       - name: Install test requirements
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,7 @@ We recommend setting up a Python virtual environment to install the test depende
 
 ### Integration tests
 
-Integration tests require the addition of [docker](https://docs.docker.com/engine/install/) or [podman](https://podman.io/getting-started/installation) and [docker-compose](https://docs.docker.com/compose/install/).
-We recommend installing the Python implementation of `docker-compose` via pip:
-
-```
-pip install docker-compose
-```
+Integration tests require the addition of [docker](https://docs.docker.com/engine/install/) or [podman](https://podman.io/getting-started/installation).
 
 Then install the collection directly from your local repo and execute the tests:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ aiohttp
 aiokafka
 azure-servicebus
 dpath
-kafka-python
+# kafka-python
+kafka-python-ng
 psycopg
 pyyaml
 systemd-python; sys_platform != 'darwin'

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,6 +5,7 @@ asyncmock
 pytest-asyncio
 pytest-timeout
 ansible
+podman-compose
 requests
 ansible-rulebook
 tox

--- a/tests/integration/event_source_kafka/test_kafka_source.py
+++ b/tests/integration/event_source_kafka/test_kafka_source.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 
 import pytest
 from kafka import KafkaProducer
@@ -21,9 +22,9 @@ def kafka_certs():
 def kafka_broker():
     cwd = os.path.join(TESTS_PATH, "event_source_kafka")
     print(cwd)
-    result = subprocess.run(["docker-compose", "up", "-d"], cwd=cwd, check=True)
+    result = subprocess.run([sys.executable, "-m", "podman_compose", "up", "-d"], cwd=cwd, check=True)
     yield result
-    subprocess.run(["docker-compose", "down", "-v"], cwd=cwd, check=True)
+    subprocess.run([sys.executable, "-m", "podman_compose", "down", "-v"], cwd=cwd, check=True)
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,18 @@ requires =
     pylint
 
 [testenv]
-basepython = python3.9, python3.10
+basepython = python3.9, python3.10, python3.11, python3.12
 [testenv:lint]
 deps = pre-commit
 desc = Run linters
 commands = pre-commit run -a
+
+[testenv:integration]
+description = Run integration tests
+deps = -r{toxinidir}/test_requirements.txt
+commands =
+    ansible-galaxy collection install .
+    pytest tests/integration -vvv -s
 
 [testenv:ruff]
 deps = -r{toxinidir}/lint_requirements.txt


### PR DESCRIPTION
- Fixed broken integration tests because docker-compose is not installed.
- Simplify documentation about integration

Note that the python implementation of docker-compose is abandoned
and was not updated in 3+ years, not installing on several platforms.

Instead, podman-compose is actively maintained and is also able to
make use of docker-compose when found on disk, so it can be used
as a safe replacement.
