### PR TITLE
Correct psycopg requirements

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -39,7 +39,7 @@ jobs:
           other_names: |
             lint
             integration
-          platforms: linux
+          platforms: linux,macos
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
@@ -67,7 +67,8 @@ jobs:
           path: ansible_collections/ansible/eda
           submodules: true
 
-      - name: Install package dependencies
+      - name: Install package dependencies (ubuntu)
+        if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
           sudo apt-get update
           sudo apt-get --assume-yes --no-install-recommends install libsystemd0 libsystemd-dev pkg-config

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiokafka
 azure-servicebus
 dpath
 kafka-python
-psycopg
+psycopg[binary,pool]  # extras needed to avoid install failure on macos-aarch64
 systemd-python; sys_platform != 'darwin'
 watchdog
 xxhash

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -7,5 +7,5 @@ azure-servicebus
 dpath
 pytest<8  # https://github.com/ansible/ansible/issues/82713
 pytest-asyncio
-psycopg
+psycopg[binary,pool]
 xxhash

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ deps = -r test_requirements.txt
 commands_pre =
   bash -c 'test "$(basename $(cd ../.. && pwd))" == ansible_collections || { echo "Repository must be cloned inside a directory structure like ansible_collections/ansible/eda in order allow ansible-test to run."; exit 3;}'
 commands =
+  # fail-fast if psycopg in not properly installed.
+  python3 -c "import psycopg"
   ansible-test sanity
   ansible-test units --venv -v --num-workers 1
 allowlist_externals =


### PR DESCRIPTION
This fixes a bug that prevented the execution of the tests on some platforms, such macos, as psycopg listed alone does not always installs a functional library:

```
E   ImportError: no pq wrapper available.
E   Attempts made:
E   - couldn't import psycopg 'c' implementation: No module named 'psycopg_c'
E   - couldn't import psycopg 'binary' implementation: No module named 'psycopg_binary'
E   - couldn't import psycopg 'python' implementation: libpq library not found
```

Also enables testing on macos using aarch64, preventing a regression related to unavailable dependencies.

Related: #219