### PR TITLE
Replace unmaintained docker-compose with podman-compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,7 @@ tox -e py
 
 ### Integration tests
 
-Integration tests require the addition of [docker](https://docs.docker.com/engine/install/) or [podman](https://podman.io/getting-started/installation) and [docker-compose](https://docs.docker.com/compose/install/).
-
+Integration tests require the addition of [docker](https://docs.docker.com/engine/install/) or [podman](https://podman.io/getting-started/installation).
 
 Then install the collection directly from your local repo and execute the tests:
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,3 +9,4 @@ pytest-timeout>=2.0.1
 requests>=2.31.0
 ansible-rulebook>=1.0.0
 tox>=4.15.1
+podman-compose

--- a/tests/integration/event_source_kafka/test_kafka_source.py
+++ b/tests/integration/event_source_kafka/test_kafka_source.py
@@ -21,9 +21,12 @@ def kafka_certs():
 def kafka_broker():
     cwd = os.path.join(TESTS_PATH, "event_source_kafka")
     print(cwd)
-    result = subprocess.run(["docker-compose", "up", "-d"], cwd=cwd, check=True)
+    # Keep --quiet-pull here is it does spam CI/CD console
+    result = subprocess.run(
+        ["podman-compose", "up", "--quiet-pull", "-d"], cwd=cwd, check=True
+    )
     yield result
-    subprocess.run(["docker-compose", "down", "-v"], cwd=cwd, check=True)
+    subprocess.run(["podman-compose", "down", "-v"], cwd=cwd, check=True)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
As python based docker-compose is unmaintained and with last release more than 3 year old, we make use of podman-compose instead, which is a wrapper that can make use of any docker-compose if found, in addition to native podman-compose tool.