### PR TITLE
Correct requirements and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,24 @@
 
 This collection contains event source plugins, event filters and example rulebooks to be used with [ansible-rulebook](https://ansible-rulebook.readthedocs.io/en/stable/).
 
-<p style="text-align: center" align="center">
-    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=integration-tests"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/integration-tests.yml/badge.svg?event=schedule"/> </a>
-    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=linters"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/linters.yml/badge.svg?event=schedule"/> </a>
-    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=tests"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/tests.yml/badge.svg?event=schedule"/> </a>
-    <a href="https://github.com/ansible/event-driven-ansible/actions?workflow=tox"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/tox.yml/badge.svg?event=schedule"/> </a>
-</p>
+<a href="https://github.com/ansible/event-driven-ansible/actions?workflow=tox"><img height="20px" src="https://github.com/ansible/event-driven-ansible/actions/workflows/tox.yml/badge.svg?event=schedule"/> </a>
 
 ## Requirements
 
-* ansible-rulebook >= 1.0.0
 * python >= 3.9
-* ansible >= 2.13
+* ansible-core >= 2.15
 
 ## Install
 
 Install the ansible.eda collection with the Ansible Galaxy CLI:
 
-```
+```shell
 ansible-galaxy collection install ansible.eda
 ```
 
-The python module dependencies are not installed by ansible-galaxy. They must be installed manually using pip:
+The Python module dependencies are not installed by ansible-galaxy. They must be installed manually using pip:
 
-```
+```shell
 pip install -r requirements.txt
 ```
 

--- a/demos/dynatrace-demo/instructions.md
+++ b/demos/dynatrace-demo/instructions.md
@@ -29,7 +29,7 @@ crashing.
 2. Have ansible.eda collection installed by ansible-galaxy
 3. Update `inventory.yml` with correct ip and user to access the client node
 4. Start the rulebook CLI:
-```
+```shell
   ansible-rulebook -i demos/dynatrace-demo/inventory.yml --rules demos/dynatrace-demo/rulebook.yml
 ```
 This rulebook starts an alertmanager source that listens on port 5050

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,4 @@
 ---
-requires_ansible: ">=2.14.0"
+# https://access.redhat.com/support/policy/updates/ansible-automation-platform
+# https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+requires_ansible: ">=2.15.0" # AAP 2.4 or newer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ansible-core>=2.15
 pyyaml>=6.0.1
 aiobotocore
 aiohttp

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,10 +1,8 @@
 -r requirements.txt
-pytest
-asyncmock
-pytest-asyncio
-pytest-timeout
-ansible
-requests
-ansible-rulebook
-tox
-ansible-core
+pytest>=7.0.0
+asyncmock>=0.4.2
+pytest-asyncio>=0.20.0
+pytest-timeout>=2.0.1
+requests>=2.31.0
+ansible-rulebook>=1.0.0
+tox>=4.15.1


### PR DESCRIPTION
- Mention ansible-core>=2.15 in meta/runtime.yml
- Mention ansible-core>=2.15 in runtime requirements to avoid accidents during testing
- Avoid mentioning 'ansible' community bundle in test_requirements.txt
- Correct docs badges
- Remove ansible-rulebook requirement from readme, being a test dependency
- Mention code block types in readme
- Added minimal versions for test requirements (performance and supportability)
