### PR TITLE
Add bindep file for testing system dependencies

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -2,9 +2,11 @@
 -Djava
 GSSAPI
 OAUTHBEARER
+PYTHONUNBUFFERED
 alertmanager
 basepython
 benthomasosn
+bindep
 buildx
 cafile
 capath
@@ -13,6 +15,7 @@ confluentinc
 conninfo
 containerd
 darglint
+deadsnakes
 digestmod
 dynatrace
 envlist

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Determine matrix
         id: generate_matrix
-        uses: coactions/dynamic-matrix@v1
+        uses: coactions/dynamic-matrix@v2
         with:
           min_python: "3.9"
           max_python: "3.12"
@@ -39,6 +39,7 @@ jobs:
           other_names: |
             lint
             integration
+            sanity
           platforms: linux,macos
   build:
     name: ${{ matrix.name }}
@@ -73,10 +74,13 @@ jobs:
           sudo apt remove -y docker-compose
           sudo apt-get update -y
           sudo apt-get --assume-yes --no-install-recommends install -y apt-transport-https curl libsystemd0 libsystemd-dev pkg-config
+          sudo add-apt-repository ppa:deadsnakes/ppa
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt update -y
-          sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+          sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin python3.11-dev python3.11-venv python3.11-full
+          # installs pip for alternative python versions that do not ship it
+          python3.11 -m ensurepip
           # Do not install docker-compose-plugin because it would v1 (broken due to not working with newer requests library)
           sudo systemctl enable --now docker
           sudo curl -sL "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,7 @@
+# ubuntu: 22.04 (default py312, others from deadsnakes)
+libsystemd0 [test platform:debian]
+libsystemd-dev [test platform:debian]
+pkg-config  [test platform:debian]
+
+# for sanity testing to pass we need all supported python versions installed:
+python3.11-dev [test platform:ubuntu-noble]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ skipsdist = true # this repo is not a python package
 isolated_build = true
 requires =
   tox >= 4.6.3
+  tox-extra >= 2.0.0 # bindep check
   setuptools >= 65.3.0 # editable installs
 
 [testenv]
@@ -31,6 +32,7 @@ isolated_build = true
 ;   py310: true
 setenv =
     PIP_NO_BUILD_ISOLATION = 1
+    PYTHONUNBUFFERED = 1
 passenv =
   CURL_CA_BUNDLE  # https proxies, https://github.com/tox-dev/tox/issues/1437
   FORCE_COLOR
@@ -66,3 +68,9 @@ commands =
   # risky: not safe for development it affects user setup
   ansible-galaxy collection install .
   pytest tests/integration -vvv -s
+
+[testenv:sanity]
+deps = -r test_requirements.txt
+description = Run ansible-test sanity on all python versions
+commands =
+  ansible-test sanity


### PR DESCRIPTION
- Adds bindep file
- Enable testing of bindep fi on CI/CD via tox-extra plugin
