### PR TITLE
Run sanity with all supported python versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,8 +38,9 @@ jobs:
           default_python: "3.9"
           other_names: |
             lint
-            integration
-            sanity
+            py39-integration
+            py39-sanity
+            py312-sanity
           platforms: linux,macos
   build:
     name: ${{ matrix.name }}
@@ -78,8 +79,10 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt update -y
-          sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin python3.11-dev python3.11-venv python3.11-full
+          sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin python3.9-dev python3.9-venv python3.10-dev python3.10-venv python3.10-dev python3.10-venv python3.11-dev python3.11-venv shellcheck
           # installs pip for alternative python versions that do not ship it
+          python3.9 -m ensurepip
+          python3.10 -m ensurepip
           python3.11 -m ensurepip
           # Do not install docker-compose-plugin because it would v1 (broken due to not working with newer requests library)
           sudo systemctl enable --now docker

--- a/bindep.txt
+++ b/bindep.txt
@@ -3,5 +3,11 @@ libsystemd0 [test platform:debian]
 libsystemd-dev [test platform:debian]
 pkg-config  [test platform:debian]
 
-# for sanity testing to pass we need all supported python versions installed:
+# For sanity testing to pass we need all supported Python versions installed:
+python3.9-dev [test platform:ubuntu-noble]
+python3.9-venv [test platform:ubuntu-noble]
+python3.10-dev [test platform:ubuntu-noble]
+python3.10-venv [test platform:ubuntu-noble]
 python3.11-dev [test platform:ubuntu-noble]
+python3.11-venv [test platform:ubuntu-noble]
+shellcheck [test platform:ubuntu-noble]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # cspell: ignore TOXPYTHON setenv passenv REQPASS PYTHONPYCACHEPREFIX PYTHONIOENCODING PYTHONBREAKPOINT
 
 [tox]
-envlist = lint, darglint, py, integration
+envlist = lint, darglint, py, sanity, integration
 skipsdist = true # this repo is not a python package
 isolated_build = true
 requires =
@@ -13,17 +13,15 @@ requires =
   setuptools >= 65.3.0 # editable installs
 
 [testenv]
-description = Run sanity and unit tests
-basepython =
-  py39: {env:TOXPYTHON:python3.9}
-  py310: {env:TOXPYTHON:python3.10}
+description =
+  Run unit tests
+  py{39,310,311,312,313}: with {basepython}
 deps = -r test_requirements.txt
 commands_pre =
   bash -c 'test "$(basename $(cd ../.. && pwd))" == ansible_collections || { echo "Repository must be cloned inside a directory structure like ansible_collections/ansible/eda in order allow ansible-test to run."; exit 3;}'
 commands =
   # fail-fast if psycopg in not properly installed.
   python3 -c "import psycopg"
-  ansible-test sanity
   ansible-test units --venv -v --num-workers 1
 allowlist_externals =
   bash
@@ -52,6 +50,13 @@ passenv =
 # https://tox.wiki/en/latest/upgrading.html#editable-mode
 package = editable
 
+[testenv:py{39,310,311,312,313}]
+description =
+  Run unit tests
+  py{39,310,311,312,313}: with {basepython}
+
+
+
 [testenv:lint]
 deps = pre-commit
 description = Run linters
@@ -59,18 +64,24 @@ commands = pre-commit run -a
 
 [testenv:darglint]
 deps = darglint
+description = Run darglint
 commands = darglint -s numpy -z full extensions/eda/plugins
 
-[testenv:integration]
+[testenv:integration,py{39,310,311,312,313}-integration]
 deps = -r test_requirements.txt
-description = Run integration tests
+description =
+  Run integration tests
+  py{39,310,311,312,313}: with {basepython}
 commands =
   # risky: not safe for development it affects user setup
   ansible-galaxy collection install .
   pytest tests/integration -vvv -s
 
-[testenv:sanity]
+[testenv:sanity,py{39,310,311,312,313}-sanity]
 deps = -r test_requirements.txt
-description = Run ansible-test sanity on all python versions
+description =
+  Run ansible-test sanity
+  py{39,310,311,312,313}: with {basepython}
 commands =
+  ansible --version
   ansible-test sanity


### PR DESCRIPTION
Note that we run sanity with py39, which will make use of ansible 2.15, and with py39 which will make use of ansible 2.17, which do have a different range of python versions they do test with.