### PR TITLE
Add support for python 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -39,6 +39,7 @@ jobs:
           other_names: |
             lint
             py39-integration
+            py312-integration
             py39-sanity
             py312-sanity
           platforms: linux,macos

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@ aiohttp
 aiokafka
 azure-servicebus
 dpath
-kafka-python
+# https://github.com/dpkp/kafka-python/issues/2412#issuecomment-2030459360
+kafka-python; python_version < "3.12"
+kafka-python-ng;  python_version >= "3.12"
 psycopg[binary,pool]  # extras needed to avoid install failure on macos-aarch64
 systemd-python; sys_platform != 'darwin'
 watchdog


### PR DESCRIPTION
To be noted that without this change, integration tests would fail with python3.12. We could switch to `kafka-python-ng` for all versions, but I considered that to reduce impact as I do not know what other changes were merged in to that branch.