### PR TITLE
Run sanity check after linting

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,15 +37,18 @@ jobs:
           min_python: "3.9"
           max_python: "3.12"
           default_python: "3.9"
+          # Wwe run sanity with 3 different versions of ansible as the result
+          # can be different. Each of them is testing with all supported
+          # python versions, regardless the tox pyXY name.
           other_names: |
-            lint
-            py39:tox -e py39-sanity;tox -e py39-unit;tox -e py39-integration;tox -e coverage
-            py310:tox -e py310-sanity;tox -e py310-unit; tox -e py310-integration;tox -e coverage
-            py311:tox -e py311-sanity;tox -e py311-unit; tox -e py311-integration;tox -e coverage
-            py312:tox -e py312-sanity;tox -e py312-unit; tox -e py312-integration;tox -e coverage
-            py39-macos:tox -e py39-sanity;tox -e py39-unit;tox -e py39-integration;tox -e coverage
-            py312-macos:tox -e py312-sanity;tox -e py312-unit;tox -e py312-integration;tox -e coverage
-            py311-linux-arm64:tox -e py312-sanity;tox -e py312-unit;tox -e py312-integration;tox -e coverage
+            lint-sanity:tox -e lint;tox -e py39-sanity-ansible2.15;tox -e py310-sanity-ansible2.16;tox -e py311-sanity-ansible2.17
+            py39:tox -e py39-unit;tox -e py39-integration;tox -e coverage
+            py310:tox -e py310-unit; tox -e py310-integration;tox -e coverage
+            py311:tox -e py311-unit; tox -e py311-integration;tox -e coverage
+            py312:tox -e py312-unit; tox -e py312-integration;tox -e coverage
+            py39-macos:tox -e py39-unit;tox -e py39-integration;tox -e coverage
+            py312-macos:tox -e py312-unit;tox -e py312-integration;tox -e coverage
+            py311-linux-arm64:tox -e py312-unit;tox -e py312-integration;tox -e coverage
           # ^ arm64 runner is using py311 for matching python version used in AAP 2.5
           platforms: linux,macos,linux-arm64:ubuntu-24.04-arm64-2core
           skip_explode: "1"
@@ -99,7 +102,7 @@ jobs:
 
       - name: Set pre-commit cache
         uses: actions/cache@v4
-        if: ${{ matrix.name == 'lint' }}
+        if: ${{ contains(matrix.name, 'lint') }}
         with:
           path: |
             ~/.cache/pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -89,11 +89,17 @@ commands =
   ansible-test coverage report --requirements --omit '.tox/*,tests/*' --color --all --show-missing -v --truncate 0
   ansible-test coverage combine --export={envdir}
 
-[testenv:sanity,py{39,310,311,312,313}-sanity]
-deps = -r test_requirements.txt
+[testenv:sanity,py{39,310,311,312,313}-sanity,py{39,310,311}-sanity-ansible2.15,py{310,311,312}-sanity-ansible{2.16,2.17,2.18}]
+deps =
+  py{39,310,311}-sanity-ansible2.15: ansible-core>=2.15,<2.16
+  py{310,311,312}-sanity-ansible2.16: ansible-core>=2.16,<2.17
+  py{310,311,312}-sanity-ansible2.17: ansible-core>=2.17,<2.18
+  py{310,311,312}-sanity-ansible2.18: ansible-core>=2.18,<2.19
+  -r test_requirements.txt
 description =
   Run ansible-test sanity
   py{39,310,311,312,313}: with {basepython}
+
 commands =
   ansible --version
   ansible-test sanity -v --requirements --coverage --truncate 0 --junit {posargs}


### PR DESCRIPTION
Speedup GHA execution by running sanity within lint job and avoiding
to run each before each unit test one.

It should be noted that sanity tox execution is already running for
all python versions anyway, so there is no need to run it more than
once.

Related: #272