### PR TITLE
Make docs building logic more resilient

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -3,14 +3,11 @@ libsystemd0 [test platform:debian]
 libsystemd-dev [test platform:debian]
 pkg-config  [test platform:debian]
 
-# docs
-rsync [test platform:debian]
-
 # For sanity testing to pass we need all supported Python versions installed:
-python3.9-dev [test platform:ubuntu-noble]
-python3.9-venv [test platform:ubuntu-noble]
-python3.10-dev [test platform:ubuntu-noble]
-python3.10-venv [test platform:ubuntu-noble]
-python3.11-dev [test platform:ubuntu-noble]
-python3.11-venv [test platform:ubuntu-noble]
-shellcheck [test platform:ubuntu-noble]
+python3.9-dev [py39 platform:ubuntu-noble]
+python3.9-venv [py39 platform:ubuntu-noble]
+python3.10-dev [py310 platform:ubuntu-noble]
+python3.10-venv [py310 platform:ubuntu-noble]
+python3.11-dev [py311 platform:ubuntu-noble]
+python3.11-venv [py311 platform:ubuntu-noble]
+shellcheck [lint platform:ubuntu-noble]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ skipsdist = true # this repo is not a python package
 isolated_build = true
 requires =
   tox >= 4.6.3
-  ; tox-extra >= 2.0.0 # bindep check
+  tox-extra >= 2.0.1 # bindep check
   setuptools >= 65.3.0 # editable installs
 
 [testenv]
@@ -132,6 +132,7 @@ deps =
 commands_pre =
   # --force must remain here or we risk on building docs for older version
   ansible-galaxy collection install --force .
+  bash -c "command -v rsync || { 'Building docs with antsibull-docs require rsync, please install it.'; exit 1;}"
 commands =
   antsibull-docs sphinx-init --project="Event Driven Ansible Collection" --title="Event Driven Ansible Collection" --html-short-title="ansible.eda" --fail-on-error --use-current --squash-hierarchy --dest-dir=docs ansible.eda
   bash ./docs/build.sh


### PR DESCRIPTION
- restore tox-extra plugin
- update bindep.txt to remove rsync (RTD) but add a check for it in tox.ini docs
- bindep: avoid installing extra python version all the time (soft test deps)
- assure we force install collection before building docs