### PR TITLE
fix: ensure correct required params for event streams

### DIFF
--- a/plugins/modules/event_stream.py
+++ b/plugins/modules/event_stream.py
@@ -145,7 +145,7 @@ def main() -> None:
         (
             "state",
             "present",
-            ("name", "credential_name"),
+            ("name", "credential_name", "organization_name", "event_stream_type"),
         )
     ]
 

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -225,6 +225,7 @@
         name: "{{ event_stream_name }}"
         credential_name: "{{ credential_name_basic }}"
         organization_name: Default
+        event_stream_type: Basic Event Stream
       register: _result
 
     - name: Get information about a rulebook

--- a/tests/integration/targets/event_stream/tasks/main.yml
+++ b/tests/integration/targets/event_stream/tasks/main.yml
@@ -46,6 +46,7 @@
         name: "{{ event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
+        event_stream_type: Basic Event Stream
       check_mode: true
       register: _result
 
@@ -60,6 +61,7 @@
         name: "{{ event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
+        event_stream_type: Basic Event Stream
       register: _result
 
     - name: Check event stream is not created again
@@ -73,6 +75,7 @@
         name: "{{ event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
+        event_stream_type: Basic Event Stream
       register: _result
 
     # [WARNING]: The field eda_credential_id of unknown 2 has encrypted data and may


### PR DESCRIPTION
event stream type is mandatory. Tests fail with:
```
TASK [activation : Create an event stream] *************************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but all of the following are missing: event_stream_type"}
```