### PR TITLE
feat: add sync capability to project module

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -224,7 +224,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: ${{ matrix.name }}
           # verbose: true # optional (default = false)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ansible
 name: eda
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.1.0
+version: 2.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -173,7 +173,7 @@ class Client:
 
     def post(self, path: str, **kwargs: Any) -> Response:
         resp = self.request("POST", path, **kwargs)
-        if resp.status == 201:
+        if resp.status in [201, 202]:
             return resp
         raise EDAHTTPError(f"HTTP error {resp.json}")
 

--- a/tests/integration/targets/project/tasks/create.yml
+++ b/tests/integration/targets/project/tasks/create.yml
@@ -67,3 +67,44 @@
   assert:
     that:
       - r.changed
+
+- name: Check create project with partial name match
+  loop:
+    - "{{ project_name }}_test_partial"
+    - "{{ project_name }}"
+  ansible.eda.project:
+    name: "{{ item }}"
+    url: "{{ url }}"
+    description: "Example project description"
+    organization_name: Default
+    state: present
+  register: r
+
+- name: Check if create projects with partial name match
+  loop: "{{ r.results }}"
+  assert:
+    that:
+      - item.changed
+
+- name: Delete project with partial name match
+  loop:
+    - "{{ project_name }}"
+    - "{{ project_name }}_test_partial"
+  ansible.eda.project:
+    name: "{{ item }}"
+    state: absent
+
+- name: Check create project with missing url
+  ansible.eda.project:
+    name: "{{ project_name }}"
+    description: "Example project description"
+    organization_name: Default
+    state: present
+  register: r
+  ignore_errors: true
+
+- name: Check if missing url is required
+  assert:
+    that:
+      - r.failed
+      - "'Parameter url is required' in r.msg"

--- a/tests/integration/targets/project/tasks/delete.yml
+++ b/tests/integration/targets/project/tasks/delete.yml
@@ -4,9 +4,6 @@
 
 - name: Delete operation without required name parameter
   ansible.eda.project:
-    controller_host: "{{ controller_host }}"
-    controller_username: "{{ controller_username }}"
-    controller_password: "{{ controller_password }}"
     state: absent
   ignore_errors: true
   register: r
@@ -19,10 +16,6 @@
 
 - name: Delete non-existing project in check mode
   ansible.eda.project:
-    controller_host: "{{ controller_host }}"
-    controller_username: "{{ controller_username }}"
-    controller_password: "{{ controller_password }}"
-    validate_certs: "{{ controller_verify_ssl }}"
     name: "{{ project_name }}"
     state: absent
   check_mode: true

--- a/tests/integration/targets/project/tasks/main.yml
+++ b/tests/integration/targets/project/tasks/main.yml
@@ -22,11 +22,12 @@
     - name: Define variables for credential and decision environment
       set_fact:
         project_name: "test_project_{{ test_id }}"
-        url: "https://example.com/ansible/eda-server"
+        url: "https://github.com/ansible/eda-sample-project"
 
     - include_tasks: create.yml
     - include_tasks: delete.yml
     - include_tasks: update.yml
+    - include_tasks: sync.yml
   always:
     - name: Clean up - project
       ansible.eda.project:

--- a/tests/integration/targets/project/tasks/sync.yml
+++ b/tests/integration/targets/project/tasks/sync.yml
@@ -1,0 +1,86 @@
+---
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Create non existing project with sync
+  block:
+    - name: Create non existing project with sync
+      ansible.eda.project:
+        name: "{{ project_name }}_test_sync"
+        url: "{{ url }}"
+        description: "Example project description"
+        organization_name: Default
+        state: present
+        sync: true
+      register: r
+
+    - name: Check project creation
+      assert:
+        that:
+          - r.changed
+  always:
+    - name: Clean up - project
+      ansible.eda.project:
+        name: "{{ project_name }}_test_sync"
+        state: absent
+      ignore_errors: true
+
+- name: Sync existing project
+  block:
+    - name: Create project before sync
+      ansible.eda.project:
+        name: "{{ project_name }}_test_sync"
+        url: "{{ url }}"
+        description: "Example project description"
+        organization_name: Default
+        state: present
+      register: r
+
+    # need to wait for project creation otherwise sync can fail
+    - name: Wait for project creation
+      pause:
+        seconds: 5
+
+    - name: Sync project
+      ansible.eda.project:
+        name: "{{ project_name }}_test_sync"
+        sync: true
+      register: r
+
+    - name: Get info project after sync
+      ansible.eda.project_info:
+        name: "{{ project_name }}_test_sync"
+      register: r_info
+
+    - name: Check project sync
+      assert:
+        that:
+          - r.changed
+          - r_info.projects[0].modified_at != r_info.projects[0].created_at
+  always:
+    - name: Clean up - project
+      ansible.eda.project:
+        name: "{{ project_name }}_test_sync"
+        state: absent
+      ignore_errors: true
+
+- name: Check wrong parameters with sync enabled
+  block:
+    - name: Try to sync non existing project without url
+      ansible.eda.project:
+        name: "{{ project_name }}_test_sync"
+        sync: true
+      register: r
+      ignore_errors: true
+
+    - name: Check if sync non existing project without url
+      assert:
+        that:
+          - r.failed
+          - "'Parameter url is required' in r.msg"
+  always:
+    - name: Clean up - project
+      ansible.eda.project:
+        name: "{{ project_name }}_test_sync"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
**Why:**
Project module misses the sync capability. An existing project can be synced (pull changes from the repo) and this have be able to be done from the module. 
jira: https://issues.redhat.com/browse/AAP-32264

**How:**
We remove the constraint to define the url when state is present because the project might already exists, url is only required when the project needs to be created, we check it in advance to check the requirement of the url and to check if the sync operation can be performed. We add the new parameter "sync" to run the synchronization (it is an async task in the backend) if the project already exists. The client needs to be updated because the backend can also return 202 for a POST operation. 

Include:
- A new sync parameter and logic related. 
- A new generic "create" method to run a post request
- A fix of `get_exactly_one` helper that generated undesired behaviors when a name search returns results based on a partial match. 
- A minor fix by initializing `project_type` variable which could be unbound. 
- Tests added and updated for the new behavior.
- A minor fix in tests that they had defined unnecessary variables that prevented to execute the tests locally. 
- Updates the project url in tests with a public valid url. 




