### PR TITLE
fix: remove event_stream_type for event_stream module

### DIFF
--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -225,7 +225,6 @@
         name: "{{ event_stream_name }}"
         credential_name: "{{ credential_name_basic }}"
         organization_name: Default
-        event_stream_type: "basic"
       register: _result
 
     - name: Get information about a rulebook

--- a/tests/integration/targets/event_stream/tasks/main.yml
+++ b/tests/integration/targets/event_stream/tasks/main.yml
@@ -47,7 +47,6 @@
         credential_name: "{{ credential_name }}"
         organization_name: Default
         forward_events: false
-        event_stream_type: "basic"
       check_mode: true
       register: _result
 
@@ -62,7 +61,6 @@
         name: "{{ event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
-        event_stream_type: "basic"
       register: _result
 
     - name: Check event stream is created
@@ -76,7 +74,6 @@
         name: "{{ event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
-        event_stream_type: "basic"
       register: _result
 
     # [WARNING]: The field eda_credential_id of unknown 2 has encrypted data and may
@@ -98,7 +95,6 @@
         name: "{{ new_event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
-        event_stream_type: "basic"
       register: _result
 
     - name: Check event stream update
@@ -112,7 +108,6 @@
         name: "{{ new_event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
-        event_stream_type: "basic"
       register: _result
 
     # [WARNING]: The field eda_credential_id of unknown 5 has encrypted data and may
@@ -139,7 +134,6 @@
         name: "{{ new_event_stream_name }}"
         credential_name: "{{ credential_name }}"
         organization_name: Default
-        event_stream_type: "basic"
         headers: "Authorization,Custom-Header"
         forward_events: true
       register: _result


### PR DESCRIPTION
event_stream_type is not necessary to create the event stream and it is misleading since the user has no way to know what is the value for it and it will end up in unexpected errors if its sent to the api. The type is already set by the backend based on the credential chosen. The API will remove it as well, its existence is an error and it only exists in the UI in order to filter existing credentials by type. 

Jira: https://issues.redhat.com/browse/AAP-33196