### PR TITLE
ci: pin tox-extra version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ skipsdist = true # this repo is not a python package
 isolated_build = true
 requires =
   tox >= 4.6.3
-  tox-extra >= 2.0.1 # bindep check
+  tox-extra == 2.0.2 # bindep check
   setuptools >= 65.3.0 # editable installs
 ignore_basepython_conflict = false
 


### PR DESCRIPTION
Solves CI failing pipelines by pinning tox-extra dependency. 

Ref: https://github.com/tox-dev/tox-extra/issues/121 