### PR TITLE
Check if param flag values are defined, not truthiness

### DIFF
--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -412,13 +412,13 @@ def create_params(
     if module.params.get("restart_policy"):
         activation_params["restart_policy"] = module.params["restart_policy"]
 
-    if module.params.get("enabled"):
+    if module.params.get("enabled") is not None:
         activation_params["is_enabled"] = module.params["enabled"]
 
     if not is_aap_24 and module.params.get("log_level"):
         activation_params["log_level"] = module.params["log_level"]
 
-    if not is_aap_24 and module.params.get("swap_single_source"):
+    if not is_aap_24 and module.params.get("swap_single_source") is not None:
         activation_params["swap_single_source"] = module.params["swap_single_source"]
 
     return activation_params

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -273,7 +273,7 @@
 
     - name: Assert that rulebook activation is disabled
       ansible.builtin.assert:
-        that: 
+        that:
           - not _result_activation_info.activations[0].is_enabled
 
     - name: List all the rulebook activations
@@ -413,7 +413,7 @@
 
     - name: Assert that swap single source flag is disabled
       ansible.builtin.assert:
-        that: 
+        that:
           - not _result_activation_info.activations[0].swap_single_source
 
     - name: Delete project

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -269,6 +269,11 @@
     - name: Get information about the rulebook activation
       ansible.eda.rulebook_activation_info:
         name: "{{ activation_name }}"
+      register: _result_activation_info
+
+    - name: Assert that rulebook activation is disabled
+      ansible.builtin.assert:
+        that: not _result_activation_info.activations[0].is_enabled
 
     - name: List all the rulebook activations
       ansible.eda.rulebook_activation_info:

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -411,11 +411,6 @@
         that:
           - event_stream_name in (source_mappings_dict | map(attribute='event_stream_name') | list)
 
-    - name: Assert that swap single source flag is disabled
-      ansible.builtin.assert:
-        that:
-          - not _result_activation_info.activations[0].swap_single_source
-
     - name: Delete project
       ansible.eda.project:
         name: "{{ project_name }}"

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -273,7 +273,8 @@
 
     - name: Assert that rulebook activation is disabled
       ansible.builtin.assert:
-        that: not _result_activation_info.activations[0].is_enabled
+        that: 
+          - not _result_activation_info.activations[0].is_enabled
 
     - name: List all the rulebook activations
       ansible.eda.rulebook_activation_info:
@@ -385,6 +386,7 @@
         enabled: False
         awx_token_name: "{{ awx_token_name }}"
         organization_name: Default
+        swap_single_source: False
         event_streams:
           - event_stream: "{{ event_stream_name }}"
             source_name: "{{ _result_rulebook_info.rulebooks[0].sources[0].name }}"
@@ -408,6 +410,11 @@
       assert:
         that:
           - event_stream_name in (source_mappings_dict | map(attribute='event_stream_name') | list)
+
+    - name: Assert that swap single source flag is disabled
+      ansible.builtin.assert:
+        that: 
+          - not _result_activation_info.activations[0].swap_single_source
 
     - name: Delete project
       ansible.eda.project:


### PR DESCRIPTION
Addresses #365 by checking if module parameters which represent flags are defined, preventing evaluation of their truthyness. Current behavior will ignore an incoming value of false and default back to true because of the conditional logic:

Example:
`module.params["enabled"] = False`
`if module.params.get("enabled")` evaluates to False, but the intent is to determine if it has been defined, so we want this to evaluate to True.

This PR addresses the same issue for `swap_single_source` param.