### PR TITLE
fix: [AAP-38952] incorrect 'image_url' in tests

### DIFF
--- a/tests/integration/targets/decision_environment/tasks/main.yml
+++ b/tests/integration/targets/decision_environment/tasks/main.yml
@@ -23,7 +23,7 @@
     - name: Define variables for credential and decision environment
       set_fact:
         decision_env_name: "Test_Decision_Env_{{ test_id }}"
-        image_url: "https://quay.io/repository/ansible/eda-server"
+        image_url: "quay.io/ansible/ansible-rulebook:main"
 
     - include_tasks: create.yml
     - include_tasks: delete.yml

--- a/tests/integration/targets/decision_environment_info/tasks/main.yml
+++ b/tests/integration/targets/decision_environment_info/tasks/main.yml
@@ -24,7 +24,7 @@
     - name: Define variables for credential and decision environment
       set_fact:
         decision_env_name: "Test_Decision_Env_{{ test_id }}"
-        image_url: "https://quay.io/repository/ansible/eda-server"
+        image_url: "quay.io/ansible/ansible-rulebook:main"
 
     - include_tasks: list.yml
   always:


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-38952

The 'image_url' field is incorrect in the decision_enrivonment tests and it does not correspond to valid OCI image/tag/naming standards.

Proper validation of the image_url field was introduced here [1], and the tests of the collection must reflect it.

[1] https://github.com/ansible/eda-server/pull/1188