### PR TITLE
fix: AAP-39412 incorrect credential in examples

### DIFF
--- a/examples/eda-setup.yml
+++ b/examples/eda-setup.yml
@@ -80,7 +80,7 @@
       ansible.eda.event_stream:
         organization_name: "{{ organization_name }}"
         name: basic event stream
-        credential_name: basic event stream
+        credential_name: basic event stream credential
         event_stream_type: Basic Event Stream
 
     - name: Get the event stream generated


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-39412

The eda-setup.yml example playbook currently fails because the credential name passed to create a basic event stream is different from the credential created before.

This commit fixes this issue and allows the example playbook to continue.