### PR TITLE
feat: [AAP-38755] add documentation for azure_service_bus, file and file_watch plugins

### DIFF
--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -1,21 +1,3 @@
-"""azure_service_bus.py.
-
-An ansible-rulebook event source module for receiving events from an Azure service bus
-
-Arguments:
----------
-    conn_str: The connection string to connect to the Azure service bus
-    queue_name: The name of the queue to pull messages from
-    logging_enable: Whether to turn on logging. Default to True
-
-Example:
--------
-    - ansible.eda.azure_service_bus:
-        conn_str: "{{connection_str}}"
-        queue_name: "{{queue_name}}"
-
-"""
-
 import asyncio
 import concurrent.futures
 import contextlib
@@ -23,6 +5,33 @@ import json
 from typing import Any
 
 from azure.servicebus import ServiceBusClient
+
+DOCUMENTATION = r"""
+---
+short_description: Receive events from an Azure service bus.
+description:
+  - An ansible-rulebook event source module for receiving events from an Azure service bus.
+options:
+  conn_str:
+    description:
+      - The connection string to connect to the Azure service bus.
+    type: str
+  queue_name:
+    description:
+      - The name of the queue to pull messages from.
+    type: str
+  logging_enable:
+    description:
+      - Whether to turn on logging.
+    type: bool
+    default: true
+"""
+
+EXAMPLES = r"""
+- ansible.eda.azure_service_bus:
+    conn_str: "{{connection_str}}"
+    queue_name: "{{queue_name}}"
+"""
 
 
 def receive_events(

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -11,15 +11,19 @@ DOCUMENTATION = r"""
 short_description: Receive events from an Azure service bus.
 description:
   - An ansible-rulebook event source module for receiving events from an Azure service bus.
+  - In order to get the service bus and the connection string, refer to 
+    https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-python-how-to-use-queues?tabs=passwordless
 options:
   conn_str:
     description:
       - The connection string to connect to the Azure service bus.
     type: str
+    required: true
   queue_name:
     description:
       - The name of the queue to pull messages from.
     type: str
+    required: true
   logging_enable:
     description:
       - Whether to turn on logging.

--- a/extensions/eda/plugins/event_source/azure_service_bus.py
+++ b/extensions/eda/plugins/event_source/azure_service_bus.py
@@ -11,7 +11,7 @@ DOCUMENTATION = r"""
 short_description: Receive events from an Azure service bus.
 description:
   - An ansible-rulebook event source module for receiving events from an Azure service bus.
-  - In order to get the service bus and the connection string, refer to 
+  - In order to get the service bus and the connection string, refer to
     https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-python-how-to-use-queues?tabs=passwordless
 options:
   conn_str:

--- a/extensions/eda/plugins/event_source/file.py
+++ b/extensions/eda/plugins/event_source/file.py
@@ -1,20 +1,3 @@
-"""file.py.
-
-An ansible-rulebook event source plugin for loading facts from YAML files
-initially and when the file changes.
-
-Arguments:
----------
-    files - a list of YAML files
-
-Example:
--------
-    - ansible.eda.file:
-      files:
-        - fact.yml
-
-"""
-
 import pathlib
 from asyncio import Queue
 from typing import Any, Union
@@ -22,6 +5,26 @@ from typing import Any, Union
 import yaml
 from watchdog.events import FileSystemEvent, RegexMatchingEventHandler
 from watchdog.observers import Observer
+
+DOCUMENTATION = r"""
+---
+short_description: Load facts from YAML files initially and when the file changes.
+description:
+  - An ansible-rulebook event source plugin for loading facts from YAML files
+    initially and when the file changes.
+options:
+  files:
+    description:
+      - A list of YAML files.
+    type: list
+    elements: str
+"""
+
+EXAMPLES = r"""
+- ansible.eda.file:
+    files:
+      - fact.yml
+"""
 
 
 def send_facts(queue: Queue[Any], filename: Union[str, bytes]) -> None:

--- a/extensions/eda/plugins/event_source/file.py
+++ b/extensions/eda/plugins/event_source/file.py
@@ -15,7 +15,7 @@ description:
 options:
   files:
     description:
-      - A list of YAML files.
+      - A list of file paths pointing to YAML files.
     type: list
     elements: str
 """
@@ -23,7 +23,7 @@ options:
 EXAMPLES = r"""
 - ansible.eda.file:
     files:
-      - fact.yml
+      - /path/to/fact.yml
 """
 
 

--- a/extensions/eda/plugins/event_source/file_watch.py
+++ b/extensions/eda/plugins/event_source/file_watch.py
@@ -1,29 +1,38 @@
-r"""file_watch.py.
-
-An ansible-rulebook event source plugin for watching file system changes.
-
-Arguments:
----------
-    path: The directory to watch for changes.
-    ignore_regexes: A list of regular expressions to ignore changes
-    recursive: Recursively watch the path if true
-
-Example:
--------
-    - name: file_watch
-      file_watch:
-        path: "{{src_path}}"
-        recursive: true
-        ignore_regexes: ['.*\\.pytest.*', '.*__pycache__.*', '.*/.git.*']
-
-"""
-
 import asyncio
 import concurrent.futures
 from typing import Any
 
 from watchdog.events import FileSystemEvent, RegexMatchingEventHandler
 from watchdog.observers import Observer
+
+DOCUMENTATION = r"""
+---
+short_description: Load facts from YAML files initially and when the file changes.
+description:
+  - An ansible-rulebook event source plugin for loading facts from YAML files
+    initially and when the file changes.
+options:
+  path:
+    description:
+      - The directory to watch for changes.
+    type: str
+  ignore_regexes:
+    description:
+      - A list of regular expressions to ignore changes.
+    type: list
+    elements: str
+  recursive:
+    description:
+      - Recursively watch the path if true.
+    type: bool
+"""
+
+EXAMPLES = r"""
+- ansible.eda.file_watch:
+    path: "{{src_path}}"
+    recursive: true
+    ignore_regexes: ['.*\\.pytest.*', '.*__pycache__.*', '.*/.git.*']
+"""
 
 
 def watch(

--- a/extensions/eda/plugins/event_source/file_watch.py
+++ b/extensions/eda/plugins/event_source/file_watch.py
@@ -7,15 +7,15 @@ from watchdog.observers import Observer
 
 DOCUMENTATION = r"""
 ---
-short_description: Load facts from YAML files initially and when the file changes.
+short_description: Watch file system changes.
 description:
-  - An ansible-rulebook event source plugin for loading facts from YAML files
-    initially and when the file changes.
+  - An ansible-rulebook event source plugin for watching file system changes.
 options:
   path:
     description:
       - The directory to watch for changes.
     type: str
+    required: true
   ignore_regexes:
     description:
       - A list of regular expressions to ignore changes.
@@ -25,11 +25,12 @@ options:
     description:
       - Recursively watch the path if true.
     type: bool
+    required: true
 """
 
 EXAMPLES = r"""
 - ansible.eda.file_watch:
-    path: "{{src_path}}"
+    path: "/directory/to/watch"
     recursive: true
     ignore_regexes: ['.*\\.pytest.*', '.*__pycache__.*', '.*/.git.*']
 """


### PR DESCRIPTION
This PR adds documentation for both event sources azure_service_bus, file and file_watch plugins, by following the format outlined [here](https://docs.ansible.com/ansible-core/devel/dev_guide/sidecar.html).

JIRA: [AAP-38755](https://issues.redhat.com/browse/AAP-38755)