### PR TITLE
feat: [AAP-38755] add documentation for generic, journald and kafka plugins

### DIFF
--- a/extensions/eda/plugins/event_source/generic.py
+++ b/extensions/eda/plugins/event_source/generic.py
@@ -1,45 +1,3 @@
-"""A generic source plugin that allows you to insert custom data.
-
-The event data to insert into the queue is specified in the required
-parameter payload and is an array of events.
-
-Optional Parameters:
-payload_file A yaml with an array of events can be used instead of payload
-randomize    True|False Randomize the events in the payload, default False
-display      True|False Display the event data in stdout, default False
-timestamp    True|False Add an event timestamp, default False
-time_format   local|iso8601|epoch  The time format of event timestamp,
-              default local
-create_index str   The index to create for each event starts at 0
-startup_delay float  Number of seconds to wait before injecting events
-                   into the queue. Default 0
-event_delay float    Number of seconds to wait before injecting the next
-                   event from the payload. Default 0
-repeat_delay float   Number of seconds to wait before injecting a repeated
-                   event from the payload. Default 0
-loop_delay float     Number of seconds to wait before inserting the
-                   next set of events. Default 0
-shutdown_after float Number of seconds to wait before shutting down the
-                   plugin. Default 0
-loop_count int     Number of times the set of events in the payload
-                   should be repeated. Default 0
-repeat_count int   Number of times each individual event in the payload
-                   should be repeated. Default 1
-blob_size int      An arbitrary blob of blob_size bytes to be inserted
-                   into every event payload. Default is 0 don't create
-                   a blob
-final_payload dict After all the events have been sent we send the optional
-                   final payload which can be used to trigger a shutdown of
-                   the rulebook, especially when we are using rulebooks to
-                   forward messages to other running rulebooks.
-check_env_vars dict Optionally check if all the defined env vars are set
-                    before generating the events. If any of the env_var is missing
-                    or the value doesn't match the source plugin will end
-                    with an exception
-
-
-"""
-
 #  Copyright 2022 Red Hat, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,6 +24,129 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import yaml
+
+DOCUMENTATION = r"""
+---
+short_description: A generic source plugin that allows you to insert custom data.
+description:
+  - A generic source plugin that allows you to insert custom data.
+  - The event data to insert into the queue is specified in the required
+    parameter payload and is an array of events.
+options:
+  payload:
+    description:
+      - An array of events that can be used instead of payload.
+    required: true
+  payload_file:
+    description:
+      - A yaml with an array of events that can be used instead of payload.
+    type: str
+  randomize:
+    description:
+      - Randomize the events in the payload.
+    type: bool
+    default: false
+  display:
+    description:
+      - Display the event data in stdout.
+    type: bool
+    default: false
+  timestamp:
+    description:
+      - Add an event timestamp.
+    type: bool
+    default: false
+  time_format:
+    description:
+      - The format of event timestamp.
+    type: str
+    default: "local"
+    choices: ["local", "iso8601", "epoch"]
+  create_index:
+    description:
+      - The index to create for each event starts at 0.
+    type: str
+    default: ""
+  startup_delay:
+    description:
+      - The number of seconds to wait before injecting events into the queue.
+    type: float
+    default: 0
+  event_delay:
+    description:
+      - The number of seconds to wait before injecting the next event from the payload.
+    type: float
+    default: 0
+  repeat_delay:
+    description:
+      - The number of seconds to wait before injecting a repeated event from the payload.
+    type: float
+    default: 0
+  loop_delay:
+    description:
+      - The number of seconds to wait before inserting the next set of events.
+    type: float
+    default: 0
+  shutdown_after:
+    description:
+      - The number of seconds to wait before shutting down the plugin.
+    type: float
+    default: 0
+  loop_count:
+    description:
+      - The number of times the set of events in the payload should be repeated.
+    type: int
+    default: 1
+  repeat_count:
+    description:
+      - The number of times each individual event in the payload should be repeated.
+    type: int
+    default: 1
+  blob_size:
+    description:
+      - An arbitrary blob of blob_size bytes to be inserted into every event payload.
+      - Default is 0, which does not create a blob.
+    type: int
+    default: 0
+  final_payload:
+    description:
+      - After all the events have been sent we send the optional
+        final payload which can be used to trigger a shutdown of
+        the rulebook, especially when we are using rulebooks to
+        forward messages to other running rulebooks.
+    default: null
+  check_env_vars:
+    description:
+      - Optionally check if all the defined env vars are set
+        before generating the events. If any of the env_var is missing
+        or the value doesn't match the source plugin will end
+        with an exception.
+    type: dict
+    default: null
+"""
+
+EXAMPLES = r"""
+- ansible.eda.generic:
+    payload:
+      - message:
+          name: Fred
+      - message:
+          name: Barney
+    final_payload:
+      payload:
+        shutdown: true
+    randomize: true
+    display: true
+    timestamp: true
+    time_format: epoch
+    loop_count: 1
+    loop_delay: 1
+    shutdown_after: 5
+    create_index: i
+    check_env_vars:
+      MY_ENV1: abc
+      MY_ENV2: xyz
+"""
 
 
 class MissingEnvVarError(Exception):

--- a/extensions/eda/plugins/event_source/journald.py
+++ b/extensions/eda/plugins/event_source/journald.py
@@ -1,28 +1,3 @@
-"""journald.py.
-
-An ansible-events event source plugin that tails systemd journald logs.
-
-Arguments:
----------
-    match - return messages that matches this field,
-    see https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
-
-Examples:
---------
-    - name: Return severity 6 messages
-      ansible.eda.journald:
-        match: "PRIORITY=6"
-
-    - name: Return messages when sudo is used
-      ansible.eda.journald:
-        match: "_EXE=/usr/bin/sudo"
-
-    - name: Return all messages
-      ansible.eda.journald:
-        match: "ALL"
-
-"""
-
 import asyncio
 from typing import Any
 
@@ -31,6 +6,39 @@ from typing import Any
 # No such file or directory: 'pkg-config'
 # pylint: disable=import-error
 from systemd import journal  # type: ignore
+
+DOCUMENTATION = r"""
+---
+short_description: Tail systemd journald logs.
+description:
+  - An ansible-rulebook event source plugin that tails systemd journald logs.
+options:
+  match:
+    description:
+      - A string used to match messages and return them, see
+        https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html.
+    type: str
+    required: true
+  delay:
+    description:
+      - The delay (in seconds) between messages.
+    type: int
+    default: 0
+"""
+
+EXAMPLES = r"""
+- name: Return severity 6 messages
+  ansible.eda.journald:
+    match: "PRIORITY=6"
+
+- name: Return messages when sudo is used
+  ansible.eda.journald:
+    match: "_EXE=/usr/bin/sudo"
+
+- name: Return all messages
+  ansible.eda.journald:
+    match: "ALL"
+"""
 
 
 async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:  # noqa: D417
@@ -41,8 +49,7 @@ async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:  # noqa
         queue (asyncio.Queue): The queue to which journal entries will be added.
         args (dict[str, Any]): Additional arguments:
             - delay (int): The delay in seconds. Defaults to 0.
-            - match (list[str]): A list of strings to match.
-              Defaults to empty list.
+            - match (str): A string to match.
 
     Returns:
     -------

--- a/extensions/eda/plugins/event_source/kafka.py
+++ b/extensions/eda/plugins/event_source/kafka.py
@@ -1,39 +1,3 @@
-"""kafka.py.
-
-An ansible-rulebook event source plugin for receiving events via a kafka topic.
-
-Arguments:
----------
-    host:      The host where the kafka topic is hosted
-    port:      The port where the kafka server is listening
-    cafile:    The optional certificate authority file path containing certificates
-               used to sign kafka broker certificates
-    certfile:  The optional client certificate file path containing the client
-               certificate, as well as CA certificates needed to establish
-               the certificate's authenticity
-    keyfile:   The optional client key file path containing the client private key
-    password:  The optional password to be used when loading the certificate chain
-    check_hostname:  Enable SSL hostname verification. [True (default), False]
-    verify_mode: Whether to try to verify other peers' certificates and how to
-               behave if verification fails. [CERT_NONE, CERT_OPTIONAL,
-               CERT_REQUIRED (default)]
-    encoding:  Message encoding scheme. Default to utf-8
-    topic:     The kafka topic
-    group_id:  A kafka group id
-    offset:    Where to automatically reset the offset. [latest, earliest]
-               Default to latest
-    security_protocol: Protocol used to communicate with brokers. [PLAINTEXT, SSL,
-               SASL_PLAINTEXT, SASL_SSL]. Default to PLAINTEXT
-    sasl_mechanism: Authentication mechanism when security_protocol is configured.
-               [PLAIN, GSSAPI, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER].
-               Default to PLAIN.
-    sasl_plain_username: Username for SASL PLAIN authentication
-    sasl_plain_password: Password for SASL PLAIN authentication
-
-
-
-"""
-
 import asyncio
 import json
 import logging
@@ -42,6 +6,111 @@ from typing import Any
 
 from aiokafka import AIOKafkaConsumer
 from aiokafka.helpers import create_ssl_context
+
+DOCUMENTATION = r"""
+---
+short_description: Receive events via a kafka topic.
+description:
+  - An ansible-rulebook event source plugin for receiving events via a kafka topic.
+options:
+  host:
+    description:
+      - The host where the kafka topic is hosted.
+    type: str
+    required: true
+  port:
+    description:
+      - The port where the kafka server is listening.
+    type: str
+    required: true
+  cafile:
+    description:
+      - The optional certificate authority file path containing certificates
+        used to sign kafka broker certificates
+    type: str
+  certfile:
+    description:
+      - The optional client certificate file path containing the client
+        certificate, as well as CA certificates needed to establish
+        the certificate's authenticity.
+    type: str
+  keyfile:
+    description:
+      - The optional client key file path containing the client private key.
+    type: str
+  password:
+    description:
+      - The optional password to be used when loading the certificate chain.
+    type: str
+  check_hostname:
+    description:
+      - Enable SSL hostname verification.
+    type: bool
+    default: true
+  verify_mode:
+    description:
+      - Whether to try to verify other peers' certificates and how to
+        behave if verification fails.
+    type: str
+    default: "CERT_REQUIRED"
+    choices: ["CERT_NONE", "CERT_OPTIONAL", "CERT_REQUIRED"]
+  encoding:
+    description:
+      - Message encoding scheme.
+    type: str
+    default: "utf-8"
+  topic:
+    description:
+      - The kafka topic.
+    type: str
+  group_id:
+    description:
+      - A kafka group id.
+    type: str
+    default: null
+  offset:
+    description:
+      - Where to automatically reset the offset.
+    type: str
+    default: "latest"
+    choices: ["latest", "earliest"]
+  security_protocol:
+    description:
+      - Protocol used to communicate with brokers.
+    type: str
+    default: "PLAINTEXT"
+    choices: ["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]
+  sasl_mechanism:
+    description:
+      - Authentication mechanism when security_protocol is configured.
+    type: str
+    default: "PLAIN"
+    choices: ["PLAIN", "GSSAPI", "SCRAM-SHA-256", "SCRAM-SHA-512", "OAUTHBEARER"]
+  sasl_plain_username:
+    description:
+      - Username for SASL PLAIN authentication.
+    type: str
+  sasl_plain_password:
+    description:
+      - Password for SASL PLAIN authentication.
+    type: str
+"""
+
+EXAMPLES = r"""
+- ansible.eda.kafka:
+    host: "localhost"
+    port: "9092"
+    check_hostname: true
+    verify_mode: "CERT_OPTIONAL"
+    encoding: "utf-8"
+    topic: "demo"
+    group_id: "test"
+    offset: "earliest"
+    security_protocol: "SASL_PLAINTEXT"
+    sasl_mechanism: "GSSAPI"
+    sasl_plain_username: "admin"
+    sasl_plain_password: "test"
+"""
 
 
 async def main(  # pylint: disable=R0914


### PR DESCRIPTION
This PR adds documentation for both event sources generic, journald and kafka plugins, by following the format outlined [here](https://docs.ansible.com/ansible-core/devel/dev_guide/sidecar.html).

JIRA: [AAP-38755](https://issues.redhat.com/browse/AAP-38755)