### PR TITLE
fix: add support for Kafka GSSAPI

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -51,6 +51,8 @@ kaiokmo
 keygen
 keypass
 keytool
+krb5-user
+libkrb5-dev
 libpq
 libsystemd
 mydb

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           sudo apt-get -qq -o Dpkg::Use-Pty=0 remove -y docker-compose
           sudo apt-get -qq -o Dpkg::Use-Pty=0 update -y --fix-missing
-          sudo apt-get -qq -o Dpkg::Use-Pty=0 --assume-yes --no-install-recommends install -y apt-transport-https curl libsystemd0 libsystemd-dev pkg-config
+          sudo apt-get -qq -o Dpkg::Use-Pty=0 --assume-yes --no-install-recommends install -y apt-transport-https curl libsystemd0 libsystemd-dev pkg-config libkrb5-dev krb5-user
           sudo add-apt-repository ppa:deadsnakes/ppa
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null

--- a/extensions/eda/plugins/event_source/kafka.py
+++ b/extensions/eda/plugins/event_source/kafka.py
@@ -94,6 +94,14 @@ options:
     description:
       - Password for SASL PLAIN authentication.
     type: str
+  sasl_kerberos_service_name:
+    description:
+      - The service name, default is kafka
+    type: str
+  sasl_kerberos_domain_name:
+    description:
+      - The kerberos REALM
+    type: str
 """
 
 EXAMPLES = r"""
@@ -173,6 +181,8 @@ async def main(  # pylint: disable=R0914
         sasl_mechanism=args.get("sasl_mechanism", "PLAIN"),
         sasl_plain_username=args.get("sasl_plain_username"),
         sasl_plain_password=args.get("sasl_plain_password"),
+        sasl_kerberos_service_name=args.get("sasl_kerberos_service_name"),
+        sasl_kerberos_domain_name=args.get("sasl_kerberos_domain_name"),
     )
 
     await kafka_consumer.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ansible-core>=2.15
 pyyaml>=6.0.1
 aiobotocore
 aiohttp
-aiokafka
+aiokafka[gssapi]
 azure-servicebus
 dpath
 # https://github.com/dpkp/kafka-python/issues/2412#issuecomment-2030459360

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,6 +1,6 @@
 aiobotocore
 aiohttp
-aiokafka
+aiokafka[gssapi]
 asyncio
 asyncmock
 azure-servicebus

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,10 @@ requires =
 ignore_basepython_conflict = false
 
 [testenv]
+# Currently ansible has issues loading Cython compiled modules
+# from under the ansible_collection/ansible/eda directory.
+# https://github.com/ansible/ansible/pull/84758
+env_dir=/tmp/event_driven_ansible/.tox/{env_name}
 description =
   Run unit tests
   py{39,310,311,312,313}: with {basepython}


### PR DESCRIPTION
The aiokafka package already supports GSSAPI as long as it has the correct packages installed along with kerberos.

This fix just passes in the parameters from EDA to aiokafka

The DE should have the following Kerberos packages on CentOS:
 
   * krb5-libs
   * krb5-devel

Along with the python gssapi package.

https://issues.redhat.com/browse/AAPRFE-1662