### PR TITLE
feat: [AAP-37428] add support for copy credential

### DIFF
--- a/plugins/modules/credential.py
+++ b/plugins/modules/credential.py
@@ -158,7 +158,7 @@ def main() -> None:
 
     argument_spec.update(AUTH_ARGSPEC)
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     copy_from = module.params.get("copy_from", None)
 
     required_if = []

--- a/tests/integration/targets/credential/tasks/main.yml
+++ b/tests/integration/targets/credential/tasks/main.yml
@@ -21,6 +21,7 @@
       set_fact:
         credential_name: "Test_Credential_{{ test_id }}"
         new_credential_name: "New_Test_Credential_{{ test_id }}"
+        credential_copy_name: "Test_Credential_{{ test_id }}_Copy"
         credential_type_name: "Test_CredentialType_{{ test_id }}"
 
     # CREATE
@@ -90,6 +91,68 @@
     - name: Get info about a credential
       ansible.eda.credential_info:
         name: "{{ credential_name }}"
+
+    - name: Copy credential
+      ansible.eda.credential:
+        name: "{{ credential_copy_name }}"
+        copy_from: "{{ credential_name }}"
+        organization_name: Default
+      register: _result
+
+    - name: Check credential is copied
+      assert:
+        that:
+          - _result.changed
+
+    - name: Get info about credentials
+      ansible.eda.credential_info:
+      register: _credential_info
+
+    - name: Get both created and copied credentials
+      set_fact:
+        _source_credential: "{{ _credential_info.credentials | selectattr('name', 'equalto', credential_name) | list | first }}"
+        _copied_credential: "{{ _credential_info.credentials | selectattr('name', 'equalto', credential_copy_name) | list | first }}"
+
+    - name: Assert credential fields are copied correctly
+      ansible.builtin.assert:
+        that:
+          - _source_credential | dict2items | rejectattr('key', 'in', ignored_fields) | items2dict == _copied_credential | dict2items | rejectattr('key', 'in', ignored_fields) | items2dict
+          - _source_credential.name + '_Copy' == _copied_credential.name
+      vars:
+        ignored_fields:
+          - name
+          - id
+          - created_at
+          - updated_at
+          - modified_at
+
+    - name: Copy non-existing credential
+      ansible.eda.credential:
+        name: "{{ credential_copy_name }}"
+        copy_from: "invalid_credential"
+        organization_name: Default
+      register: _result
+      ignore_errors: true
+
+    - name: Check credential copy failed
+      assert:
+        that:
+          - _result.failed
+          - "\"Unable to access 'id' of the credential to copy from\" in _result.msg"
+
+    - name: Copy credential and use existing name
+      ansible.eda.credential:
+        name: "{{ credential_copy_name }}"
+        copy_from: "{{ credential_name }}"
+        organization_name: Default
+      register: _result
+      ignore_errors: true
+
+    - name: Check credential copy failed
+      assert:
+        that:
+          - _result.failed
+          - "'eda credential with this name already exists.' in _result.msg"
 
     # UPDATE
     - name: Update credential name


### PR DESCRIPTION
This PR adds support for EDA Credentials' new copy endpoint - `/eda-credentials/<id>/copy`.