### PR TITLE
Fix YAML syntax issues in DOCUMENTATION

### DIFF
--- a/extensions/eda/plugins/event_source/aws_cloudtrail.py
+++ b/extensions/eda/plugins/event_source/aws_cloudtrail.py
@@ -11,7 +11,8 @@ DOCUMENTATION = r"""
 short_description: Receive events from an AWS CloudTrail
 description:
   - An ansible-rulebook event source module for getting events from an AWS CloudTrail.
-  - This supports all the authentication methods supported by boto library:
+  - >
+    This supports all the authentication methods supported by boto library:
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
 options:
   access_key:

--- a/extensions/eda/plugins/event_source/aws_sqs_queue.py
+++ b/extensions/eda/plugins/event_source/aws_sqs_queue.py
@@ -11,7 +11,8 @@ DOCUMENTATION = r"""
 short_description: Receive events via an AWS SQS queue.
 description:
   - An ansible-rulebook event source plugin for receiving events via an AWS SQS queue.
-  - This supports all the authentication methods supported by boto library:
+  - >
+    This supports all the authentication methods supported by boto library:
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
 options:
   access_key:

--- a/extensions/eda/plugins/event_source/pg_listener.py
+++ b/extensions/eda/plugins/event_source/pg_listener.py
@@ -36,7 +36,8 @@ notes:
     special to enable chunking. The sender, which is the pg_notify
     action from ansible-rulebook, will decide if chunking needs to
     happen based on the size of the payload.
-  - If the messages are over 7KB the sender will chunk the messages
+  - |
+    If the messages are over 7KB the sender will chunk the messages
     into separate payloads with each payload having the following
     keys:
     * _message_chunked_uuid   The unique message uuid


### PR DESCRIPTION
A few of the `event_source` plugins had invalid DOCUMENTATION due to YAML syntax errors, this PR addresses them by using folded or block scalars.

Generally, if there is a `:` in the string, with whitespace to the right, YAML will split it as a key/value pair. Using folded or block scalars will resolve the issue as the whole field will be treated as a string.