### PR TITLE
chore: release 2.6

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ansible
 name: eda
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.5.0
+version: 2.6.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/credential.py
+++ b/plugins/modules/credential.py
@@ -36,7 +36,7 @@ options:
       - If set, copies the specified credential.
       - The new credential will be created with the name given in the C(name) parameter.
     type: str
-    version_added: '3.0.0'
+    version_added: '2.6.0'
   inputs:
     description:
       - Credential inputs where the keys are var names used in templating.

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -30,7 +30,7 @@ options:
       - If set, copies the specified rulebook activation.
       - The new rulebook activation will be created with the name given in the C(name) parameter.
     type: str
-    version_added: 3.0.0
+    version_added: 2.6.0
   description:
     description:
       - The description of the rulebook activation.


### PR DESCRIPTION
Also includes a minor fix in the documentation from the latest changes about copy activation/credential, which is not a breaking change. 