### PR TITLE
fix: add restart activation AAP-37681

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,11 @@ tests/integration/integration_config.yml
 docs/build/
 docs/rst/*.rst
 docs/temp-rst
+
 # Other
 tests/integration/inventory
+**/.DS_Store
+.ansible/
 
 # Collection specific
 importer_result.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # venv
 venv
+.venv/
 
 # tests
 tests/output

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -173,7 +173,7 @@ class Client:
 
     def post(self, path: str, **kwargs: Any) -> Response:
         resp = self.request("POST", path, **kwargs)
-        if resp.status in [201, 202]:
+        if resp.status in [201, 202, 204]:
             return resp
         raise EDAHTTPError(f"HTTP error {resp.json}")
 

--- a/plugins/module_utils/controller.py
+++ b/plugins/module_utils/controller.py
@@ -411,3 +411,27 @@ class Controller:
             raise EDAError(response.json["__all__"])
         msg = f"Unable to copy from {item_type} {copy_from}: {response.status}"
         raise EDAError(msg)
+
+    def restart_if_needed(
+        self,
+        existing_item: dict[str, Any],
+        endpoint: str,
+    ) -> dict[str, bool]:
+        if not endpoint:
+            msg = "Unable to restart activation, missing endpoint"
+            raise EDAError(msg)
+        if not existing_item:
+            msg = "Unable to restart activation, missing activation parameter"
+            raise EDAError(msg)
+        if self.module.check_mode:
+            return {"changed": True}
+
+        item_id = existing_item["id"]
+        response = self.post_endpoint(endpoint, data={"id": item_id})
+        if response.status in [200, 201, 204]:
+            self.result["changed"] = True
+            return self.result
+        if response.json and "__all__" in response.json:
+            raise EDAError(response.json["__all__"])
+        msg = f"Error restarting activation with ID: {existing_item['id']}"
+        raise EDAError(msg)

--- a/tests/integration/targets/activation/tasks/activation_lifecycle.yml
+++ b/tests/integration/targets/activation/tasks/activation_lifecycle.yml
@@ -1,0 +1,138 @@
+---
+- name: Rulebook activation integration tests for lifecycle operations
+  module_defaults:
+    group/ansible.eda.eda:
+      aap_hostname: "{{ aap_hostname }}"
+      aap_username: "{{ aap_username }}"
+      aap_password: "{{ aap_password }}"
+      aap_verify_ssl: "{{ aap_verify_ssl }}"
+  block:
+    - name: Generate a random_string for the test
+      set_fact:
+        random_string: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+      when: random_string is not defined
+
+    - name: Generate a ID for the test
+      set_fact:
+        test_id: "{{ random_string | to_uuid }}"
+      when: test_id is not defined
+
+    - name: Define variables for credential and project
+      set_fact:
+        organization_name: "Default"
+        decision_env_name: "Test_Decision_Env_{{ test_id }}"
+        activation_name: "Test_Activation_{{ test_id }}"
+        project_name: "Test_Project_{{ test_id }}"
+        de_image_url: "quay.io/ansible/ansible-rulebook:main"
+        scm_url: https://github.com/ansible/eda-sample-project.git
+        rulebook_name: "range_long_running.yml"
+
+    - name: Create a new project
+      debugger: on_failed
+      ansible.eda.project:
+        name: "{{ project_name }}"
+        description: "Test Project Description"
+        url: "{{ scm_url }}"
+        organization_name: "{{ organization_name}}"
+        state: present
+      register: project_creation
+
+    - name: Wait for the project to be imported
+      register: project_status
+      until: project_status.projects[0].import_state == "completed"
+      retries: 30
+      delay: 2
+      ansible.eda.project_info:
+        name: "{{ project_name }}"
+
+    - name: Create a new decision environment
+      ansible.eda.decision_environment:
+        name: "{{ decision_env_name }}"
+        description: "Test Decision Environment Description"
+        image_url: "{{ de_image_url }}"
+        organization_name: "{{ organization_name}}"
+
+    - name: Create the activation
+      ansible.eda.rulebook_activation:
+        name: "{{ activation_name }}"
+        description: "Example Activation description"
+        project_name: "{{ project_name }}"
+        rulebook_name: "{{ rulebook_name }}"
+        decision_environment_name: "{{ decision_env_name }}"
+        enabled: True
+        organization_name: "{{ organization_name}}"
+
+    - name: wait for the activation to be running
+      register: activation_status
+      until: activation_status.activations[0].status == "running"
+      retries: 30
+      delay: 2
+      ansible.eda.rulebook_activation_info:
+        name: "{{ activation_name }}"
+
+    - name: Restart activation
+      ansible.eda.rulebook_activation:
+        name: "{{ activation_name }}"
+        organization_name: "{{ organization_name}}"
+        restart: true
+
+    - name: wait for the activation to restart
+      register: activation_status
+      until: activation_status.activations[0].restart_count == 1
+      retries: 30
+      delay: 2
+      ansible.eda.rulebook_activation_info:
+        name: "{{ activation_name }}"
+
+    - name: Check if activation was restarted
+      ansible.builtin.assert:
+        that:
+          - activation_status.activations[0].restart_count == 1
+          - activation_status.activations[0].status in ["running", "starting"]
+
+    - name: Restart activation without activation name
+      register: result
+      ansible.eda.rulebook_activation:
+        name: ""
+        organization_name: "{{ organization_name}}"
+        restart: true
+      ignore_errors: true
+
+    - name: Verify Restart Failed without Activation name
+      ansible.builtin.assert:
+        that:
+          - result.failed
+        fail_msg: "Restart operation did not fail as expected without necessary name parameter"
+        success_msg: "Restart operation failed as expected without necessary name parameter"
+
+    - name: Restart activation in check_mode
+      ansible.eda.rulebook_activation:
+        name: "{{ activation_name }}"
+        organization_name: "{{ organization_name}}"
+        restart: true
+      check_mode: true
+      register: result
+
+    - name: Verify Restart activation in check_mode
+      assert:
+        that:
+          - result.changed
+
+  always:
+    - name: Delete project
+      ansible.eda.project:
+        name: "{{ project_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete rulebook activation
+      ansible.eda.rulebook_activation:
+        name: "{{ activation_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete decision environment
+      ansible.eda.decision_environment:
+        name: "{{ decision_env_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -7,6 +7,10 @@
       aap_password: "{{ aap_password }}"
       aap_verify_ssl: "{{ aap_verify_ssl }}"
   block:
+    - name: Run Lifecycle tests
+      ansible.builtin.include_tasks:
+        file: ./activation_lifecycle.yml
+    
     - name: Generate a random_string for the test
       set_fact:
         random_string: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -10,7 +10,7 @@
     - name: Run Lifecycle tests
       ansible.builtin.include_tasks:
         file: ./activation_lifecycle.yml
-    
+
     - name: Generate a random_string for the test
       set_fact:
         random_string: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"


### PR DESCRIPTION
Rulebook activation [module](https://console.redhat.com/ansible/automation-hub/repo/published/ansible/eda/content/module/rulebook_activation/) lacks support for restarting the activation. As any existing operation it should be supported. 
Jira: https://issues.redhat.com/browse/AAP-37681