### PR TITLE
fix: [AAP-41820] add proxy param for project create module

### DIFF
--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -36,6 +36,11 @@ options:
       description:
         - The git URL of the project.
       type: str
+    proxy:
+      description:
+        - Proxy used to access HTTP or HTTPS servers.
+      type: str
+      version_added: '2.7.0'
     credential:
       description:
         - The name of the credential to associate with the project.
@@ -73,6 +78,7 @@ EXAMPLES = r"""
     name: "Example Project"
     description: "Example project description"
     url: "https://example.com/project1"
+    proxy: "https://example.com"
     organization_name: Default
     state: present
 
@@ -123,6 +129,7 @@ def main() -> None:
         new_name=dict(),
         description=dict(),
         url=dict(),
+        proxy=dict(),
         credential=dict(),
         organization_name=dict(type="str", aliases=["organization"]),
         state=dict(choices=["present", "absent"], default="present"),
@@ -151,6 +158,7 @@ def main() -> None:
     organization_name = module.params.get("organization_name")
     project_name = module.params.get("name")
     url = module.params.get("url")
+    proxy = module.params.get("proxy")
     sync_enabled = module.params.get("sync")
     project_type = {}
 
@@ -191,6 +199,8 @@ def main() -> None:
         project_type_params["description"] = description
     if url:
         project_type_params["url"] = url
+    if proxy:
+        project_type_params["proxy"] = proxy
 
     credential_id = None
     if credential:

--- a/tests/integration/targets/project/tasks/create.yml
+++ b/tests/integration/targets/project/tasks/create.yml
@@ -20,8 +20,9 @@
 - name: Create project
   ansible.eda.project:
     name: "{{ project_name }}"
-    url: "{{ url }}"
     description: "Example project description"
+    url: "{{ url }}"
+    proxy: "{{ proxy }}"
     organization_name: Default
     state: present
   register: r
@@ -34,8 +35,9 @@
 - name: Create project again
   ansible.eda.project:
     name: "{{ project_name }}"
-    url: "{{ url }}"
     description: "Example project description"
+    url: "{{ url }}"
+    proxy: "{{ proxy }}"
     organization_name: Default
     state: present
   register: r

--- a/tests/integration/targets/project/tasks/main.yml
+++ b/tests/integration/targets/project/tasks/main.yml
@@ -23,6 +23,7 @@
       set_fact:
         project_name: "test_project_{{ test_id }}"
         url: "https://github.com/ansible/eda-sample-project"
+        proxy: "http://eda:testpass@host.docker.internal:3128"
 
     - include_tasks: create.yml
     - include_tasks: delete.yml

--- a/tests/run-staging
+++ b/tests/run-staging
@@ -11,7 +11,7 @@ fi
 # Start EDA API Server
 bash -c 'cd ${TOX_WORK_DIR}/eda-server/tools/docker && \
 docker compose -p eda -f docker-compose-stage.yaml pull -q && \
-docker compose -p eda -f docker-compose-stage.yaml up -d && \
+docker compose -p eda -f docker-compose-stage.yaml --profile proxy up -d && \
 until curl -s http://localhost:8000/_healthz | grep -q "OK"; do \
 echo "Waiting for API to be ready..."; sleep 1; done'
 


### PR DESCRIPTION
This PR adds a missing param for adding `proxy` when creating a project through project module.

JIRA: [AAP-41820](https://issues.redhat.com/browse/AAP-41820)