### PR TITLE
Move Activation Copy to Separate Module-AAP-42215

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -8,9 +8,11 @@ Buzachis
 EDAHTTP
 FQCN
 GSSAPI
+Kaio
 Kasurde
 Nikhil
 OAUTHBEARER
+Oliveira
 PYTHONUNBUFFERED
 Passw
 akasurde
@@ -85,3 +87,4 @@ toxinidir
 trustore
 truststore
 unshallow
+whitt

--- a/.config/manifest.txt
+++ b/.config/manifest.txt
@@ -86,6 +86,7 @@ plugins/modules/event_stream_info.py
 plugins/modules/project.py
 plugins/modules/project_info.py
 plugins/modules/rulebook_activation.py
+plugins/modules/rulebook_activation_copy.py
 plugins/modules/rulebook_activation_info.py
 plugins/modules/rulebook_info.py
 plugins/modules/user.py

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -19,6 +19,7 @@ action_groups:
     - project_info
     - rulebook_info
     - rulebook_activation
+    - rulebook_activation_copy
     - rulebook_activation_info
     - user
 plugin_routing:

--- a/plugins/module_utils/controller.py
+++ b/plugins/module_utils/controller.py
@@ -417,6 +417,7 @@ class Controller:
         existing_item: dict[str, Any],
         endpoint: str,
     ) -> dict[str, bool]:
+        response = None
         if not endpoint:
             msg = "Unable to restart activation, missing endpoint"
             raise EDAError(msg)
@@ -429,6 +430,7 @@ class Controller:
         item_id = existing_item["id"]
         response = self.post_endpoint(endpoint, data={"id": item_id})
         if response.status in [200, 201, 204]:
+            self.result["id"] = item_id
             self.result["changed"] = True
             return self.result
         if response.json and "__all__" in response.json:

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -537,19 +537,6 @@ def main() -> None:
     argument_spec.update(AUTH_ARGSPEC)
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     restart = module.params.get("restart", None)
-    required_if = []
-    if not restart:
-        required_if = [
-            (
-                "state",
-                "present",
-                ("name", "rulebook_name", "decision_environment_name", "project_name"),
-            )
-        ]
-
-    module = AnsibleModule(
-        argument_spec=argument_spec, required_if=required_if, supports_check_mode=True
-    )
 
     if not HAS_YAML:
         module.fail_json(

--- a/plugins/modules/rulebook_activation_copy.py
+++ b/plugins/modules/rulebook_activation_copy.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: rulebook_activation_copy
+short_description: Copy rulebook activations in the EDA Controller
+description:
+  - This module allows the user to copy rulebook activations in the EDA Controller.
+options:
+  name:
+    description:
+      - The name of the new rulebook activation.
+    type: str
+    required: true
+  copy_from:
+    description:
+      - Name of the existing rulebook activation to copy.
+    type: str
+    required: true
+    version_added: 2.6.0
+"""
+
+EXAMPLES = r"""
+- name: Copy an existing rulebook activation
+  ansible.eda.rulebook_activation_copy:
+    name: "Example Rulebook Activation - copy"
+    copy_from: "Example Rulebook Activation"
+"""
+
+RETURN = r"""
+id:
+  description: ID of the rulebook activation.
+  returned: when exists
+  type: int
+  sample: 37
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils.arguments import AUTH_ARGSPEC
+from ..module_utils.client import Client
+from ..module_utils.controller import Controller
+from ..module_utils.errors import EDAError
+
+
+def main() -> None:
+    argument_spec = dict(
+        name=dict(type="str", required=True),
+        copy_from=dict(type="str", required=True),
+    )
+
+    argument_spec.update(AUTH_ARGSPEC)
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    copy_from = module.params.get("copy_from")
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    client = Client(
+        host=module.params.get("controller_host"),
+        username=module.params.get("controller_username"),
+        password=module.params.get("controller_password"),
+        timeout=module.params.get("request_timeout"),
+        validate_certs=module.params.get("validate_certs"),
+    )
+
+    name = module.params.get("name")
+    controller = Controller(client, module)
+
+    # Attempt to find rulebook activation based on the provided name
+    activation = {}
+    try:
+        activation = controller.get_exactly_one("activations", name=copy_from)
+    except EDAError as e:
+        module.fail_json(msg=f"Failed to get rulebook activation: {e}")
+
+    try:
+        result = controller.copy_if_needed(
+            name,
+            copy_from,
+            endpoint=f"activations/{activation['id']}/copy",
+            item_type="activation",
+        )
+        module.exit_json(**result)
+    except KeyError as e:
+        module.fail_json(msg=f"Unable to access {e} of the activation to copy from.")
+    except EDAError as e:
+        module.fail_json(msg=f"Failed to copy rulebook activation: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/rulebook_activation_copy.py
+++ b/plugins/modules/rulebook_activation_copy.py
@@ -11,6 +11,9 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: rulebook_activation_copy
+author:
+  - "Kaio Oliveira (@kaiokmo)"
+  - "Brandon W (@b-whitt)"
 short_description: Copy rulebook activations in the EDA Controller
 description:
   - This module allows the user to copy rulebook activations in the EDA Controller.

--- a/plugins/modules/rulebook_activation_copy.py
+++ b/plugins/modules/rulebook_activation_copy.py
@@ -26,6 +26,8 @@ options:
     type: str
     required: true
     version_added: 2.6.0
+extends_documentation_fragment:
+  - ansible.eda.eda_controller.auths
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/rulebook_activation_copy.py
+++ b/plugins/modules/rulebook_activation_copy.py
@@ -17,6 +17,7 @@ author:
 short_description: Copy rulebook activations in the EDA Controller
 description:
   - This module allows the user to copy rulebook activations in the EDA Controller.
+version_added: 2.7.0
 options:
   name:
     description:
@@ -28,7 +29,6 @@ options:
       - Name of the existing rulebook activation to copy.
     type: str
     required: true
-    version_added: 2.6.0
 extends_documentation_fragment:
   - ansible.eda.eda_controller.auths
 """

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -42,6 +42,7 @@
         credential_name_basic: "Test_CredentialBasic_{{ test_id }}"
         credential_name_aap: "Test_CredentialAAP_{{ test_id }}"
         credential_name_container_registry: "Test_CredentialContainer_Registry_{{ test_id }}"
+        organization_name: "Default"
 
     - name: Create a new credential type
       ansible.eda.credential_type:
@@ -101,7 +102,7 @@
           password: secret
           ssh_key_data: "{{ ssh_key_data }}"
           ssh_key_unlock: "passphrase"
-        organization_name: Default
+        organization_name: "{{ organization_name}}"
       register: credential_creation
 
     - name: Assert that the credential was created successfully
@@ -114,7 +115,7 @@
       ansible.eda.credential:
         name: "{{ credential_name_aap }}"
         credential_type_name: Red Hat Ansible Automation Platform
-        organization_name: Default
+        organization_name: "{{ organization_name }}"
         inputs:
           host: "{{ aap_hostname }}"
           username: "{{ aap_username }}"
@@ -191,7 +192,7 @@
         description: "Test Decision Environment Description"
         credential: "{{ credential_name_container_registry }}"
         image_url: "{{ image_url }}"
-        organization_name: Default
+        organization_name: "{{ organization_name}}"
       register: decision_environment_creation
 
     - name: Create a new rulebook activation in check mode
@@ -204,7 +205,7 @@
         state: disabled
         eda_credentials:
           - "{{ credential_name_aap }}"
-        organization_name: Default
+        organization_name: "{{ organization_name}}"
       check_mode: true
       register: _result
 
@@ -222,14 +223,13 @@
         decision_environment_name: "{{ decision_env_name }}"
         eda_credentials:
           - "{{ credential_name_aap }}"
-        organization_name: Default
+        organization_name: "{{ organization_name}}"
       register: _result
 
     - name: Copy rulebook activation
-      ansible.eda.rulebook_activation:
+      ansible.eda.rulebook_activation_copy:
         name: "{{ activation_name_copy }}"
         copy_from: "{{ activation_name }}"
-        organization_name: Default
       register: _result
 
     - name: Check rulebook activation update
@@ -272,10 +272,9 @@
           - _result.changed
 
     - name: Copy non-existing activation
-      ansible.eda.rulebook_activation:
+      ansible.eda.rulebook_activation_copy:
         name: "{{ activation_name_copy }}"
         copy_from: Invalid_activation
-        organization_name: Default
       register: _result
       ignore_errors: true
 
@@ -286,15 +285,9 @@
           - "\"Unable to access 'id' of the activation to copy from.\" in _result.msg"
 
     - name: Copy activation and use existing name
-      ansible.eda.rulebook_activation:
+      ansible.eda.rulebook_activation_copy:
         name: "{{ activation_name_copy }}"
         copy_from: "{{ activation_name }}"
-        project_name: "{{ project_name }}"
-        rulebook_name: "{{ rulebook_name }}"
-        decision_environment_name: "{{ decision_env_name }}"
-        eda_credentials:
-          - "{{ credential_name_aap }}"
-        organization_name: Default
       register: _result
       ignore_errors: true
 
@@ -313,7 +306,7 @@
         state: disabled
         eda_credentials:
           - "{{ credential_name_aap }}"
-        organization_name: Default
+        organization_name: "{{ organization_name}}"
         project_name: Invalid_Project
       register: _result
       ignore_errors: true

--- a/tests/run-staging
+++ b/tests/run-staging
@@ -25,4 +25,4 @@ ansible-test coverage report --requirements --omit '.tox/*,tests/*' --color --al
 ansible-test coverage combine "--export=${TOX_ENV_DIR:-.}"
 
 # Clean up containers
-bash -c 'cd ${TOX_WORK_DIR}/eda-server/tools/docker && docker compose -p eda -f docker-compose-stage.yaml down'
+bash -c 'cd ${TOX_WORK_DIR}/eda-server/tools/docker && docker compose -p eda -f docker-compose-stage.yaml --profile proxy down'


### PR DESCRIPTION
A new module is created for the copy action to copy the activation.

It has been discussed and decided that we shall move the existing copy action from the activation module to a separate module. The copy action shall take only one parameter which is the name of the copied activation. The resulting activation should be in disabled state. [https://issues.redhat.com/browse/AAP-42215]

