### PR TITLE
Fix docker compose down command in 'tests' script

### DIFF
--- a/tests/run-staging
+++ b/tests/run-staging
@@ -25,4 +25,4 @@ ansible-test coverage report --requirements --omit '.tox/*,tests/*' --color --al
 ansible-test coverage combine "--export=${TOX_ENV_DIR:-.}"
 
 # Clean up containers
-bash -c 'cd ${TOX_WORK_DIR}/eda-server/tools/docker && docker compose -p eda -f docker-compose-stage.yaml down'
+bash -c 'cd ${TOX_WORK_DIR}/eda-server/tools/docker && docker compose -p eda -f docker-compose-stage.yaml --profile proxy down'


### PR DESCRIPTION
Hotfix: After we introduced the usage of the proxy profile with #414, we didn't include the same profile in the 'down' command. This leaves behind the squid service as well as its container, when it should be removed as well when "docker compose down" is issued.