### PR TITLE
fix: [AAP-42971] fix syntax issues in event source plugins

### DIFF
--- a/extensions/eda/plugins/event_source/alertmanager.py
+++ b/extensions/eda/plugins/event_source/alertmanager.py
@@ -42,8 +42,10 @@ options:
     default: "."
   skip_original_data:
     description:
-      - true: put only alert data to the queue
-      - false: put sequentially both the received original data and each parsed alert item to the queue.
+      - >
+        true: put only alert data to the queue
+      - >
+        false: put sequentially both the received original data and each parsed alert item to the queue.
     type: bool
     default: false
 """

--- a/extensions/eda/plugins/event_source/webhook.py
+++ b/extensions/eda/plugins/event_source/webhook.py
@@ -77,7 +77,7 @@ options:
     default: "x-hub-signature-256"
   hmac_format:
     description:
-      -The optional HMAC signature format format.
+      - The optional HMAC signature format format.
     type: str
     default: "hex"
     choices: ["hex", "base64"]


### PR DESCRIPTION
- add folded scalar to treat `:` as a text in documentation content.

JIRA: [AAP-42971](https://issues.redhat.com/browse/AAP-42971)