### PR TITLE
fix: pass in optional arguments to sqs

### DIFF
--- a/tests/unit/event_source/test_aws_sqs_queue.py
+++ b/tests/unit/event_source/test_aws_sqs_queue.py
@@ -20,16 +20,29 @@ async def test_receive_from_sqs(eda_queue: ListQueue) -> None:
         message1 = {
             "MessageId": "1",
             "Body": "Hello World",
-            "ReceiptHandle": None,
+            "ReceiptHandle": "abcdef",
         }
         message2 = {
             "MessageId": "2",
             "Body": '{"Say":"Hello World"}',
-            "ReceiptHandle": None,
+            "ReceiptHandle": "xyz123",
+        }
+        delete_response1 = {
+            "Id": "1",
+            "ReceiptHandle": "abcdef",
+        }
+        delete_response2 = {
+            "Id": "2",
+            "ReceiptHandle": "xyz123",
+            "Code": "405",
+            "Message": "Failed to delete Message",
+            "SenderFault": True
         }
 
         response = {"Messages": [message1, message2]}
+        delete_response = {"Successful": [delete_response1], "Failed": [delete_response2]}
         client.receive_message = AsyncMock(side_effect=[response, ValueError()])
+        client.delete_message_batch = AsyncMock(side_effect=[delete_response, ValueError()])
 
         session.create_client.return_value = client
         session.create_client.not_async = True
@@ -41,6 +54,8 @@ async def test_receive_from_sqs(eda_queue: ListQueue) -> None:
                     "region": "us-east-1",
                     "name": "eda",
                     "delay_seconds": 1,
+                    "max_number_of_messages": 3,
+                    "queue_owner_aws_account_id": "123456",
                 },
             )
         assert eda_queue.queue[0] == {"body": "Hello World", "meta": {"MessageId": "1"}}

--- a/tests/unit/event_source/test_aws_sqs_queue.py
+++ b/tests/unit/event_source/test_aws_sqs_queue.py
@@ -36,13 +36,18 @@ async def test_receive_from_sqs(eda_queue: ListQueue) -> None:
             "ReceiptHandle": "xyz123",
             "Code": "405",
             "Message": "Failed to delete Message",
-            "SenderFault": True
+            "SenderFault": True,
         }
 
         response = {"Messages": [message1, message2]}
-        delete_response = {"Successful": [delete_response1], "Failed": [delete_response2]}
+        delete_response = {
+            "Successful": [delete_response1],
+            "Failed": [delete_response2],
+        }
         client.receive_message = AsyncMock(side_effect=[response, ValueError()])
-        client.delete_message_batch = AsyncMock(side_effect=[delete_response, ValueError()])
+        client.delete_message_batch = AsyncMock(
+            side_effect=[delete_response, ValueError()]
+        )
 
         session.create_client.return_value = client
         session.create_client.not_async = True


### PR DESCRIPTION
Based on feedback we received we are missing some key parameters from sqs queue processing. Adding additional optional parameters

* queue_owner_aws_account_id
* max_number_of_messages

https://issues.redhat.com/browse/AAP-42623

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs/client/get_queue_url.html

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs/client/receive_message.html