### PR TITLE
chore: release 2.7.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ansible
 name: eda
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.6.0
+version: 2.7.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Bump to a new release from v2.6.1 to 2.7.0