### PR TITLE
fix: really check all the URLs in url_check

### DIFF
--- a/extensions/eda/plugins/event_source/url_check.py
+++ b/extensions/eda/plugins/event_source/url_check.py
@@ -47,9 +47,9 @@ async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
         return
 
     while True:
-        try:
-            async with aiohttp.ClientSession() as session:
-                for url in urls:
+        for url in urls:
+            try:
+                async with aiohttp.ClientSession() as session:
                     async with session.get(url, verify_ssl=verify_ssl) as resp:
                         await queue.put(
                             {
@@ -61,17 +61,17 @@ async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
                             },
                         )
 
-        except aiohttp.ClientError as exc:
-            client_error = str(exc)
-            await queue.put(
-                {
-                    "url_check": {
-                        "url": url,
-                        "status": "down",
-                        "error_msg": client_error,
+            except aiohttp.ClientError as exc:
+                client_error = str(exc)
+                await queue.put(
+                    {
+                        "url_check": {
+                            "url": url,
+                            "status": "down",
+                            "error_msg": client_error,
+                        },
                     },
-                },
-            )
+                )
 
         await asyncio.sleep(delay)
 

--- a/tests/integration/event_source_url_check/test_url_check_rules_urls.yml
+++ b/tests/integration/event_source_url_check/test_url_check_rules_urls.yml
@@ -1,0 +1,34 @@
+---
+- name: Ruleset for multiple URLs check source test
+  hosts: all
+  sources:
+    - name: check sites
+      ansible.eda.url_check:
+        # big enough so only one check is performed in a test
+        delay: 3600
+        urls:
+          - http://localhost:8000/
+          - http://not-really-localhost:8000/
+          - http://localhost:8000/non-existing
+  rules:
+    - name: Endpoint is up
+      condition: event.url_check.status == "up" and event.url_check.status_code == 200
+      action:
+        run_module:
+          name: ansible.builtin.debug
+          module_args:
+            msg: "Endpoint available"
+    - name: Endpoint is unavailable
+      condition: event.url_check.status == "down" and event.url_check.status_code == 404
+      action:
+        run_module:
+          name: ansible.builtin.debug
+          module_args:
+            msg: "Endpoint unavailable"
+    - name: Host offline
+      condition: event.url_check.status == "down"
+      action:
+        run_module:
+          name: ansible.builtin.debug
+          module_args:
+            msg: "Endpoint down"


### PR DESCRIPTION
The existing logic would had caused the check to stop whenever an URL cannot be reached, no matter the reason.

Change the logic to handle the exception (in case of a request failure) within the loop for the URLs; this way, even if one fails, the remaining can still be checked. Note that the reported status is still "down" in any case: potential improvements to the reporting of check failures are to be addressed separately.

Add an additional test case for it, modelled after the existing test, to check that even in case of mixed situations (e.g. reacheable, etc) all the expected results are provided.

Fixes: https://github.com/ansible/event-driven-ansible/issues/165
Fixes: https://issues.redhat.com/browse/AAP-15246