### PR TITLE
chore: fix the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - attrs
           - bleach
           - flake8
-    exclude:
+    ignore:
       - dependency-name: attrs
       - dependency-name: bleach
       - dependency-name: flake8


### PR DESCRIPTION
The right key to exclude dependencies in an ecosystem is "ignore", not "exclude", as documented:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

Fixes commit 5659368a586fba30802e67d835c02420f45333f9.