### PR TITLE
chore: disable pylint too-many-positional-arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ disable = [
   "too-many-branches",
   "inconsistent-return-statements",
   "invalid-name",
+  "too-many-positional-arguments",
 ]
 max-line-length=120
 


### PR DESCRIPTION
pylint 3 introduces `too-many-positional-arguments` to help distinguish from `many positional-or-keyword` and `positional-only`; since we already disable the former, disable also the new checker.