### PR TITLE
fix: [AAP-41454] adjust project url edit test

### DIFF
--- a/tests/integration/targets/project/tasks/update.yml
+++ b/tests/integration/targets/project/tasks/update.yml
@@ -31,6 +31,21 @@
     that:
       - r.changed
 
+- name: Update project url
+  ansible.eda.project:
+    name: "{{ project_name }}_new"
+    new_name: "{{ project_name }}_new"
+    description: "Example project description"
+    url: "https://example.com/project1"
+    organization_name: Default
+    state: present
+  register: r
+
+- name: Check project update
+  assert:
+    that:
+      - r.changed
+
 - name: Update project again
   ansible.eda.project:
     name: "{{ project_name }}_new"


### PR DESCRIPTION
As per this PR [1], the project scm_url is now editable.
This commit simply fixes the integration test by checking that a project is updated when the URL is changed.

This integration test was previously failing because the old logic was passing a different URL in the parameters, but considering that the result was not changed. But now the project URL is editable and the test should consider the task as changed.

[1] https://github.com/ansible/eda-server/pull/1315