### PR TITLE
fix: slightly improve wait_for logic in project integration test

### DIFF
--- a/tests/integration/targets/project/tasks/scm_branch.yml
+++ b/tests/integration/targets/project/tasks/scm_branch.yml
@@ -27,6 +27,7 @@
       until:
         - r_info.projects[0].modified_at != r_info.projects[0].created_at
         - r_info.projects[0].scm_branch == scm_branch
+        - r_info.projects[0].import_state == "completed"
       retries: 30
       delay: 1
 
@@ -48,6 +49,7 @@
       until:
         - r_info.projects[0].modified_at != r_info.projects[0].created_at
         - r_info.projects[0].scm_branch == "main"
+        - r_info.projects[0].import_state == "completed"
       retries: 30
       delay: 1
 

--- a/tests/integration/targets/project/tasks/sync.yml
+++ b/tests/integration/targets/project/tasks/sync.yml
@@ -38,8 +38,13 @@
 
     # need to wait for project creation otherwise sync can fail
     - name: Wait for project creation
-      pause:
-        seconds: 5
+      ansible.eda.project_info:
+        name: "{{ project_name }}_test_sync"
+      register: r_info
+      until:
+        - r_info.projects[0].import_state == "completed"
+      retries: 30
+      delay: 1
 
     - name: Sync project
       ansible.eda.project:


### PR DESCRIPTION
This replaces a task in the project sync integration test that used the "pause" module to
wait for project creation to be completed. Now, a proper wait_for checks if the import
status is "completed".

In the scm_branch test we also now check if the import status is "completed" before continuing.