### PR TITLE
fix: [AAP-41467] don't fail on project sync already in progress

### DIFF
--- a/tests/integration/targets/project/tasks/scm_branch.yml
+++ b/tests/integration/targets/project/tasks/scm_branch.yml
@@ -12,7 +12,7 @@
         organization_name: Default
         state: present
         sync: true
-        scm_branch: "{{ scm_branch }}"
+        scm_branch: "{{ scm_branch }}"
       register: r
 
     - name: Check project with branch creation
@@ -38,9 +38,7 @@
         description: "Example project description"
         organization_name: Default
         state: present
-        sync: true
         scm_branch: "main"
-      register: re
 
     - name: Wait for project sync state with edit branch
       ansible.eda.project_info:


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-41467

As per this PR on eda-server [1], the project URL is now editable. In a previous PR in the collection [2] we already make sure that an update in the project URL causes a change status in the project, and the task returns as such.

This commit simply removes an unecessary "sync: true" that is being passed along with the request to update the project URL, given the sync is already triggered due to this change [3].

[1] https://github.com/ansible/eda-server/pull/1315
[2] https://github.com/ansible/event-driven-ansible/pull/439
[3] https://github.com/ansible/eda-server/pull/1323