### PR TITLE
Deprecate azure_service_bus

### DIFF
--- a/extensions/eda/rulebooks/github-ci-cd-rules.yml
+++ b/extensions/eda/rulebooks/github-ci-cd-rules.yml
@@ -1,7 +1,7 @@
 - name: GitHub Deploy Git Hook Rules
   hosts: all
   sources:
-    - ansible.eda.azure_service_bus:
+    - azure.azcollection.azure_service_bus:
         conn_str: "{{connection_str}}"
         queue_name: "{{queue_name}}"
       filters:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -43,7 +43,8 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+  azure.azcollection: ">=3.7.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/ansible/event-driven-ansible

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -38,3 +38,10 @@ plugin_routing:
         warning_text: >-
           activation_info has been renamed to rulebook_activation_info.
           Please update your tasks.
+    azure_service_bus:
+      redirect: azure.azcollection.azure_service_bus
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: >-
+          azure_service_bus has been moved to azure.azcollection.azure_service_bus.
+          Please update your tasks.


### PR DESCRIPTION
azure_service_bus plugin has been moved to
azure.azcollection.azure_service_bus and will be removed in a future release.

This is my first time deprecating a module that has moved so I may have missed something.  Thank you