### PR TITLE
fix: [AAP-50916] fix rulebook activation idempotence

### DIFF
--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -453,7 +453,7 @@ def create_params(
                 controller=controller,
                 module=module,
             )
-        )
+        ).rstrip("\n")
 
     # Set the remaining parameters
     if module.params.get("description"):

--- a/tests/integration/targets/activation/tasks/main.yml
+++ b/tests/integration/targets/activation/tasks/main.yml
@@ -526,7 +526,7 @@
           - not _result.changed
           - '"The specified source_name Test source name does not exist." in _result.msg'
 
-    - name: Create a rulebook activation
+    - name: Create a rulebook activation with event stream
       ansible.eda.rulebook_activation:
         name: "{{ activation_name_source_index }}"
         description: "Example Activation description"
@@ -546,6 +546,27 @@
       assert:
         that:
           - _result.changed
+
+    - name: Create a rulebook activation with event stream again (same parameters)
+      ansible.eda.rulebook_activation:
+        name: "{{ activation_name_source_index }}"
+        description: "Example Activation description"
+        project_name: "{{ project_name }}"
+        rulebook_name: "{{ rulebook_name }}"
+        decision_environment_name: "{{ decision_env_name }}"
+        state: disabled
+        eda_credentials:
+          - "{{ credential_name_aap }}"
+        organization_name: Default
+        event_streams:
+          - event_stream: "{{ event_stream_name }}"
+            source_index: 0
+      register: _result
+
+    - name: Assert that no updates were made
+      assert:
+        that:
+          - not _result.changed
 
     - name: Get information about the rulebook activation
       ansible.eda.rulebook_activation_info:


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-50916

This fixes a bug where rulebook activations with event streams were considered different even though the parameters of the tasks were the same. The cause was a difference between the information returned from the backend and the return from `yaml.dump()` when parsing the event streams from the task parameter. The `yaml.dump()` adds a trailing newline at the end of the dumped YAML string, which is the default behavior. E.g:

info from the eda-server:
```
'source_mappings': '- event_stream_id: 12\\n  event_stream_name: Test_EventStream_c99484c1-45a1-5c5f-a067-877f4e002f9c\\n  rulebook_hash: 1e0f22025ab0a4e729fb68bcb9497412c3d9f477ce5a8cb91cc2ef15e35c4dc6\\n  source_name: __SOURCE_1'
```

return from parsing the task's event streams parameter with `yaml.dump()`:
```
'source_mappings': '- event_stream_id: 12\\n  event_stream_name: Test_EventStream_c99484c1-45a1-5c5f-a067-877f4e002f9c\\n  rulebook_hash: 1e0f22025ab0a4e729fb68bcb9497412c3d9f477ce5a8cb91cc2ef15e35c4dc6\\n  source_name: __SOURCE_1\\n'
```

This causes the module to consider the objects as different, and then call the `update()` function incorrectly.

To prevent this, now we simply add a `rstrip("\n")` to the `yaml.dump()` call, which removes the trailing newline from the dumped string, allowing the module to correctly compare the two objects and detect that no changes were made, thus preserving idempotence.

A test was also added to ensure the expected behavior from activations with event streams.