### PR TITLE
docs: add deprecation information for plugins in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ This collection contains event source plugins, event filters and example ruleboo
 
 The primary purpose of this collection is to reduce manual tasks and deliver more efficient mission-critical workflows. By leveraging this collection, organizations can automate a variety of error-prone and time-consuming tasks and respond to changing conditions in any IT domain across IT environments for better agility and resiliency.
 
+## Important: Plugin Migration
+
+Several event sources and event filters have been migrated from this collection to ansible-rulebook as builtins. **Users should update their rulebooks to use the `eda.builtin` namespace.**
+
+### Migrated Event Sources
+
+- `ansible.eda.pg_listener` → `eda.builtin.pg_listener`
+- `ansible.eda.generic` → `eda.builtin.generic`
+- `ansible.eda.range` → `eda.builtin.range`
+- `ansible.eda.webhook` → `eda.builtin.webhook`
+
+### Migrated Event Filters
+
+- `ansible.eda.insert_hosts_to_meta` → `eda.builtin.insert_hosts_to_meta`
+- `ansible.eda.json_filter` → `eda.builtin.json_filter`
+- `ansible.eda.normalize_keys` → `eda.builtin.normalize_keys`
+- `ansible.eda.dashes_to_underscores` → `eda.builtin.dashes_to_underscores`
+
+**Note:** For backwards compatibility, these plugins remain available in the `ansible.eda` namespace and are automatically mapped to `eda.builtin`. However, they are no longer actively maintained in this collection. Please update your rulebooks to use the `eda.builtin` versions.
+
 ## Requirements
 
 ### Ansible version compatibility


### PR DESCRIPTION
This is an update to the README file to indicate which event filters and event sources are deprecated and moving to ansible-rulebook. It is connected to this PR in the ansible-rulebook repo: https://github.com/ansible/ansible-rulebook/pull/854.
