### PR TITLE
fix: use newer aiohttp API in url_check

### DIFF
--- a/extensions/eda/plugins/event_source/url_check.py
+++ b/extensions/eda/plugins/event_source/url_check.py
@@ -46,11 +46,15 @@ async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
     if not urls:
         return
 
+    common_get_args = {}
+    if not verify_ssl:
+        common_get_args["ssl"] = False
+
     while True:
         for url in urls:
             try:
                 async with aiohttp.ClientSession() as session:  # noqa: SIM117
-                    async with session.get(url, verify_ssl=verify_ssl) as resp:
+                    async with session.get(url, **common_get_args) as resp:
                         await queue.put(
                             {
                                 "url_check": {


### PR DESCRIPTION
Starting from aiohttp 3.0.0 (released at the beginning of 2018) there is a new way to specify the SSL verification mode, deprecating the old SSL parameters.

Hence port the `url_check module` to the new API: create a dictionary for common arguments to `ClientSession.get()`, and in case `verify_ssl` is set to false, then add `ssl=False` to these common arguments.

There should be no behaviour change to the module.