### PR TITLE
fix(tests): wait for project sync before delete

### DIFF
--- a/tests/integration/targets/project/tasks/update.yml
+++ b/tests/integration/targets/project/tasks/update.yml
@@ -63,11 +63,23 @@
     that:
       - not r.changed
 
+- name: Wait for project sync to complete before delete
+  ansible.eda.project_info:
+    name: "{{ project_name }}_new"
+  register: project_info
+  until: project_info.projects[0].import_state == "completed"
+  failed_when: project_info.projects[0].import_state == "failed"
+  retries: 30
+  delay: 2
+
 - name: Delete updated project
   ansible.eda.project:
     name: "{{ project_name }}_new"
     state: absent
   register: r
+  retries: 3
+  delay: 2
+  until: r is not failed
 
 - name: Check if delete project
   assert:


### PR DESCRIPTION
## Summary
- Fixes staging CI failure caused by eda-server#1514 (HTTP 409 on delete during sync)
- Adds sync completion poll + delete retry before cleanup in `update.yml`
- Matches existing patterns in `sync.yml`, `create.yml`, `activation_lifecycle.yml`

## Test plan
- [ ] `py311-staging` CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a polling step to wait for project import to reach "completed" (fails on "failed") before deletion.
  * Made project deletion resilient with retries (up to 3 attempts, 2-second intervals) and continued until successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->