### PR TITLE
fix(ci): use explicit path in release-drafter _extends directive

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,3 @@
 ---
 # see https://github.com/ansible/team-devtools
-_extends: ansible/team-devtools
+_extends: ansible/team-devtools:/.github/release-drafter.yml


### PR DESCRIPTION
release-drafter v7 no longer infers the config file path from a bare repo reference, breaking the ack CI check. Use the explicit path format matching the fix in ansible/ansible-creator#577.

Assisted by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release management configuration to reference a different upstream release-drafter template path, changing the base template used for automated release drafts. This is an internal tooling update and does not modify public APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->