### PR TITLE
chore: update bindep.txt to be usable

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,6 +1,7 @@
-# ubuntu: 22.04 (default py312, others from deadsnakes)
-libsystemd0 [test platform:debian]
-libsystemd-dev [test platform:debian]
-pkg-config  [test platform:debian]
-
-shellcheck [lint platform:ubuntu-noble]
+pkg-config [compile]
+gcc [compile]
+libsystemd0 [platform:debian]
+libsystemd-dev [compile platform:debian]
+systemd-devel [compile platform:rpm]
+krb5-libs [platform:rpm]
+krb5-devel [compile platform:rpm]


### PR DESCRIPTION
- drop `shellcheck`, as it is not needed
- add/move `pkg-config`, and `gcc` as general "compile" packages, as they are needed to build the binary extensions
- fix the profiles of the debian dependencies, as they are actually needed either at runtime or when building (and not when testing)
- add compile and runtime dependencies for rpm-based platforms, so the `gssapi` and `systemd` extensions can be built

This should fix almost all the dependency issues when building a custom DE using ansible-builder. The only package that still needs to be installed manually is the Python development one: since it depends on the actual Python in use in the base image, it cannot be specified here.

Fixes: #424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system-level dependency configurations to optimize compile-time requirements across multiple platforms.
  * Reorganized dependencies to distinguish between compile-time and optional test-only packages.
  * Removed unnecessary optional development tools.
  * Enhanced cross-platform support for RPM-based systems with additional runtime and development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->