### PR TITLE
feat: add k8s_pod_node_selector and k8s_pod_tolerations to rulebook_activation

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -103,8 +103,8 @@ testenv
 testpass
 testsecret
 testuser
-tolerations
 toctree
+tolerations
 toxinidir
 trustore
 truststore

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -103,6 +103,7 @@ testenv
 testpass
 testsecret
 testuser
+tolerations
 toctree
 toxinidir
 trustore

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -521,9 +521,7 @@ def create_params(
         ]
 
     if not is_aap_24 and module.params.get("k8s_pod_tolerations"):
-        activation_params["k8s_pod_tolerations"] = module.params[
-            "k8s_pod_tolerations"
-        ]
+        activation_params["k8s_pod_tolerations"] = module.params["k8s_pod_tolerations"]
 
     if not is_aap_24 and module.params.get("event_streams"):
         # Process event streams and source mappings

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -109,6 +109,27 @@ options:
       - This parameter is supported in AAP 2.5 and onwards.
         If specified for AAP 2.4, value will be ignored.
     type: str
+  k8s_pod_node_selector:
+    description:
+      - A dictionary of Kubernetes node selector labels used to schedule
+        activation job pods onto specific nodes.
+      - Only applies when the activation engine is Kubernetes.
+      - This parameter is supported in AAP 2.5 and onwards.
+        If specified for AAP 2.4, value will be ignored.
+    type: dict
+    version_added: 2.13.0
+  k8s_pod_tolerations:
+    description:
+      - A list of Kubernetes tolerations applied to activation job pods,
+        allowing them to be scheduled onto nodes with matching taints.
+      - Each entry is a dictionary with optional keys C(key), C(operator),
+        C(value), C(effect), and C(tolerationSeconds).
+      - Only applies when the activation engine is Kubernetes.
+      - This parameter is supported in AAP 2.5 and onwards.
+        If specified for AAP 2.4, value will be ignored.
+    type: list
+    elements: dict
+    version_added: 2.13.0
   swap_single_source:
     description:
       - Allow swapping of single sources in a rulebook without name match.
@@ -257,6 +278,22 @@ EXAMPLES = r"""
     organization_name: "Default"
     restart: true
     restart_on_project_update: False
+
+- name: Create a rulebook activation with Kubernetes pod metadata
+  ansible.eda.rulebook_activation:
+    name: "Example Rulebook Activation"
+    description: "Activation on dedicated nodes"
+    project_name: "Example Project"
+    rulebook_name: "hello_controller.yml"
+    decision_environment_name: "Example Decision Environment"
+    organization_name: "Default"
+    k8s_pod_node_selector:
+      workload: eda
+    k8s_pod_tolerations:
+      - key: dedicated
+        operator: Equal
+        value: eda
+        effect: NoSchedule
 
 - name: Delete a rulebook activation
   ansible.eda.rulebook_activation:
@@ -478,6 +515,16 @@ def create_params(
     if not is_aap_24 and module.params.get("k8s_service_name"):
         activation_params["k8s_service_name"] = module.params["k8s_service_name"]
 
+    if not is_aap_24 and module.params.get("k8s_pod_node_selector"):
+        activation_params["k8s_pod_node_selector"] = module.params[
+            "k8s_pod_node_selector"
+        ]
+
+    if not is_aap_24 and module.params.get("k8s_pod_tolerations"):
+        activation_params["k8s_pod_tolerations"] = module.params[
+            "k8s_pod_tolerations"
+        ]
+
     if not is_aap_24 and module.params.get("event_streams"):
         # Process event streams and source mappings
         activation_params["source_mappings"] = yaml.dump(
@@ -555,6 +602,8 @@ def main() -> None:
         organization_name=dict(type="str", aliases=["organization"]),
         eda_credentials=dict(type="list", elements="str", aliases=["credentials"]),
         k8s_service_name=dict(type="str"),
+        k8s_pod_node_selector=dict(type="dict"),
+        k8s_pod_tolerations=dict(type="list", elements="dict"),
         event_streams=dict(
             type="list",
             elements="dict",

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -109,6 +109,27 @@ options:
       - This parameter is supported in AAP 2.5 and onwards.
         If specified for AAP 2.4, value will be ignored.
     type: str
+  k8s_pod_node_selector:
+    description:
+      - A dictionary of Kubernetes node selector labels used to schedule
+        activation job pods onto specific nodes.
+      - Only applies when the activation engine is Kubernetes.
+      - This parameter is supported in AAP 2.5 and onwards.
+        If specified for AAP 2.4, value will be ignored.
+    type: dict
+    version_added: 2.13.0
+  k8s_pod_tolerations:
+    description:
+      - A list of Kubernetes tolerations applied to activation job pods,
+        allowing them to be scheduled onto nodes with matching taints.
+      - Each entry is a dictionary with optional keys C(key), C(operator),
+        C(value), C(effect), and C(tolerationSeconds).
+      - Only applies when the activation engine is Kubernetes.
+      - This parameter is supported in AAP 2.5 and onwards.
+        If specified for AAP 2.4, value will be ignored.
+    type: list
+    elements: dict
+    version_added: 2.13.0
   swap_single_source:
     description:
       - Allow swapping of single sources in a rulebook without name match.
@@ -258,6 +279,22 @@ EXAMPLES = r"""
     restart: true
     restart_on_project_update: False
 
+- name: Create a rulebook activation with Kubernetes pod metadata
+  ansible.eda.rulebook_activation:
+    name: "Example Rulebook Activation"
+    description: "Activation on dedicated nodes"
+    project_name: "Example Project"
+    rulebook_name: "hello_controller.yml"
+    decision_environment_name: "Example Decision Environment"
+    organization_name: "Default"
+    k8s_pod_node_selector:
+      workload: eda
+    k8s_pod_tolerations:
+      - key: dedicated
+        operator: Equal
+        value: eda
+        effect: NoSchedule
+
 - name: Delete a rulebook activation
   ansible.eda.rulebook_activation:
     name: "Example Rulebook Activation"
@@ -404,6 +441,12 @@ def process_event_streams(
 def create_params(
     module: AnsibleModule, controller: Controller, is_aap_24: bool
 ) -> Dict[str, Any]:
+    """Build the activation parameter dict from module args and controller lookups.
+
+    Resolves resource names to IDs for projects, rulebooks, decision environments,
+    organizations, credentials, and event streams. Handles AAP 2.4 vs 2.5+
+    differences for Kubernetes scheduling fields and other optional parameters.
+    """
     activation_params: Dict[str, Any] = {}
 
     # Get the project id, only required to get the rulebook id
@@ -478,6 +521,14 @@ def create_params(
     if not is_aap_24 and module.params.get("k8s_service_name"):
         activation_params["k8s_service_name"] = module.params["k8s_service_name"]
 
+    if not is_aap_24 and module.params.get("k8s_pod_node_selector") is not None:
+        activation_params["k8s_pod_node_selector"] = module.params[
+            "k8s_pod_node_selector"
+        ]
+
+    if not is_aap_24 and module.params.get("k8s_pod_tolerations") is not None:
+        activation_params["k8s_pod_tolerations"] = module.params["k8s_pod_tolerations"]
+
     if not is_aap_24 and module.params.get("event_streams"):
         # Process event streams and source mappings
         activation_params["source_mappings"] = yaml.dump(
@@ -527,6 +578,7 @@ def create_params(
 
 
 def main() -> None:
+    """Entry point for the rulebook_activation module."""
     argument_spec = dict(
         name=dict(type="str", required=True),
         new_name=dict(type="str"),
@@ -555,6 +607,8 @@ def main() -> None:
         organization_name=dict(type="str", aliases=["organization"]),
         eda_credentials=dict(type="list", elements="str", aliases=["credentials"]),
         k8s_service_name=dict(type="str"),
+        k8s_pod_node_selector=dict(type="dict"),
+        k8s_pod_tolerations=dict(type="list", elements="dict"),
         event_streams=dict(
             type="list",
             elements="dict",


### PR DESCRIPTION
## Summary

- Adds `k8s_pod_node_selector` (dict) and `k8s_pod_tolerations` (list of dict) parameters to the `rulebook_activation` module.
- Both are optional, Kubernetes-only, gated behind the AAP 2.5+ check, and wired through `create_params()` to the EDA Controller API.

## Why

Operators running EDA on shared Kubernetes clusters need activation job pods to target specific nodes (via node selectors) and tolerate node taints (via tolerations). The EDA Controller API already supports these fields (or will once the server-side PRs merge); this PR exposes them from the Ansible collection.

## Dependencies

This PR depends on the following eda-server changes being merged first:

- ansible/eda-server#1520 (`k8s_pod_node_selector` server support)
- ansible/eda-server#1545 (`k8s_pod_tolerations` server support)

## What changed

- `plugins/modules/rulebook_activation.py`: DOCUMENTATION, EXAMPLES, `argument_spec`, and `create_params()` updated.

Signed-off-by: Alexey Masolov <amasolov@redhat.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes pod scheduling options for activations:
    * Node selectors
    * Pod tolerations
  * Added usage documentation and examples for the new options.
  * These settings are available for AAP 2.5 and later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->