### PR TITLE
fix(tests) [AAP-75500] Add retry logic to deleting a project. Assisted-by: Claude

### DIFF
--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -314,26 +314,11 @@ def main() -> None:
         )
 
     if state == "absent":
-        # Retry delete when the server rejects it due to an active job
-        # (e.g. a sync that just finished but whose background work is
-        # still being cleaned up).
-        max_retries = 5
-        retry_delay = 3
-        for attempt in range(max_retries):
-            try:
-                ret = controller.delete_if_needed(project, endpoint=project_endpoint)
-                break
-            except EDAError as eda_err:
-                if attempt < max_retries - 1:
-                    time.sleep(retry_delay)
-                    try:
-                        project = controller.get_exactly_one(
-                            project_endpoint, name=project_name
-                        )
-                    except EDAError:
-                        pass
-                else:
-                    module.fail_json(msg=str(eda_err))
+        # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
+        try:
+            ret = controller.delete_if_needed(project, endpoint=project_endpoint)
+        except EDAError as eda_err:
+            module.fail_json(msg=str(eda_err))
         module.exit_json(**ret)
 
     project_params: dict[str, Any] = {}

--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -314,11 +314,26 @@ def main() -> None:
         )
 
     if state == "absent":
-        # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
-        try:
-            ret = controller.delete_if_needed(project, endpoint=project_endpoint)
-        except EDAError as eda_err:
-            module.fail_json(msg=str(eda_err))
+        # Retry delete when the server rejects it due to an active job
+        # (e.g. a sync that just finished but whose background work is
+        # still being cleaned up).
+        max_retries = 5
+        retry_delay = 3
+        for attempt in range(max_retries):
+            try:
+                ret = controller.delete_if_needed(project, endpoint=project_endpoint)
+                break
+            except EDAError as eda_err:
+                if attempt < max_retries - 1:
+                    time.sleep(retry_delay)
+                    try:
+                        project = controller.get_exactly_one(
+                            project_endpoint, name=project_name
+                        )
+                    except EDAError:
+                        pass
+                else:
+                    module.fail_json(msg=str(eda_err))
         module.exit_json(**ret)
 
     project_params: dict[str, Any] = {}

--- a/tests/integration/targets/project/tasks/create.yml
+++ b/tests/integration/targets/project/tasks/create.yml
@@ -61,11 +61,23 @@
     that:
       - r.changed
 
+- name: Wait for project sync to complete before delete
+  ansible.eda.project_info:
+    name: "{{ project_name }}"
+  register: project_info
+  until: project_info.projects[0].import_state == "completed"
+  failed_when: project_info.projects[0].import_state == "failed"
+  retries: 30
+  delay: 2
+
 - name: Delete project
   ansible.eda.project:
     name: "{{ project_name }}"
     state: absent
   register: r
+  retries: 3
+  delay: 2
+  until: r is not failed
 
 - name: Check if delete project
   assert:
@@ -89,6 +101,18 @@
   assert:
     that:
       - item.changed
+
+- name: Wait for project sync to complete before partial name delete
+  loop:
+    - "{{ project_name }}"
+    - "{{ project_name }}_test_partial"
+  ansible.eda.project_info:
+    name: "{{ item }}"
+  register: project_info
+  until: project_info.projects[0].import_state == "completed"
+  failed_when: project_info.projects[0].import_state == "failed"
+  retries: 30
+  delay: 2
 
 - name: Delete project with partial name match
   loop:
@@ -174,11 +198,23 @@
       - r_info.projects[0].update_revision_on_launch is true
       - r_info.projects[0].scm_update_cache_timeout == 7200
 
+- name: Wait for project sync to complete before auto-sync delete
+  ansible.eda.project_info:
+    name: "{{ project_name }}_update_revision_on_launch"
+  register: project_info
+  until: project_info.projects[0].import_state == "completed"
+  failed_when: project_info.projects[0].import_state == "failed"
+  retries: 30
+  delay: 2
+
 - name: Delete project with auto-sync
   ansible.eda.project:
     name: "{{ project_name }}_update_revision_on_launch"
     state: absent
   register: r
+  retries: 3
+  delay: 2
+  until: r is not failed
 
 - name: Check if delete project with auto-sync
   assert:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-75500

Lately Tox staging tests have been flaky because of a change to how EDA Server handles project deletes right after creating the project. Because of this change the Delete Project test [here](https://github.com/ansible/event-driven-ansible/blob/main/tests/integration/targets/project/tasks/create.yml#L64-L73) is flaky. 

This changes a test that deletes a project to have retries. This should eliminate any race conditions we might be facing. 

NOTE: Previously, this issue isn't only on this test. This PR https://github.com/ansible/event-driven-ansible/pull/531 was created to address the same issue in another test. I am using that same strategy here.  With that being said please share your thoughts and I am more than happy to rescind the PR and instead update the tests. Thank you! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of project deletion by implementing automatic retry logic. The module now attempts to delete projects up to 5 times with recovery attempts between failures, providing better handling of transient errors during the deletion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->