### PR TITLE
chore: switch to major-only version for codecov/codecov-action

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -250,7 +250,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6
         with:
           name: ${{ matrix.name }}
           # verbose: true # optional (default = false)


### PR DESCRIPTION
Any new version should generally be compatible, so avoid changes for each new minor/patch version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->