### PR TITLE
fix: add UUID validation to kafka source plugin

### DIFF
--- a/extensions/eda/plugins/event_source/kafka.py
+++ b/extensions/eda/plugins/event_source/kafka.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import uuid
 from datetime import datetime, timezone
 from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
 from typing import TYPE_CHECKING, Any
@@ -18,10 +19,14 @@ DOCUMENTATION = r"""
 short_description: Receive events via a kafka topic.
 description:
   - An ansible-rulebook event source plugin for receiving events via a kafka topic.
-  - To make each message unique you can either add message_uuid to the header or
-  - add message_uuid to the message body
-  - if both of these are missing we will use the {topic}:{partition}.{offset} to
-  - make the unique message uuid
+  - Each event is assigned a valid RFC 4122 UUID under meta.uuid.
+  - By default, a deterministic UUID5 is generated from the Kafka message
+    coordinates (topic, partition, offset).
+  - You can override this by providing a valid UUID via the "message_uuid"
+    header or the "message_uuid" field in the message body. Headers take
+    precedence over body.
+  - If a provided "message_uuid" is not a valid UUID, the generated UUID is
+    used instead and the original value is preserved under meta.message_id.
 options:
   host:
     description:
@@ -170,6 +175,7 @@ EXAMPLES = r"""
 
 MESSAGE_UUID_KEY = "message_uuid"
 QUEUE_TIMEOUT = 120
+_uuid_warning = {"emitted": False}
 
 
 def _validate_and_normalize_topics(args: dict[str, Any]) -> list[str] | None:
@@ -330,6 +336,15 @@ def get_message_timestamp(msg: ConsumerRecord) -> str:
     )
 
 
+def is_valid_uuid(value: str) -> bool:
+    """Check if a string is a valid RFC 4122 UUID."""
+    try:
+        uuid.UUID(value)
+        return True  # noqa: TRY300
+    except (ValueError, AttributeError):
+        return False
+
+
 async def main(
     queue: asyncio.Queue[Any],
     args: dict[str, Any],
@@ -389,6 +404,52 @@ async def main(
         await kafka_consumer.stop()
 
 
+def _process_event_uuid(
+    msg: ConsumerRecord,
+    headers: dict[str, str],
+    data: dict[str, Any] | str | None,
+    event: dict[str, Any],
+) -> None:
+    """Process the event UUID from headers, body, or Kafka coordinates.
+
+    Priority: header message_uuid > body message_uuid > generated UUID5.
+    If a provided message_uuid is not a valid UUID, the generated UUID is
+    used and the original value is preserved under event.meta.message_id.
+    """
+    logger = logging.getLogger()
+
+    event_uuid = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_OID,
+            f"{msg.topic}:{msg.partition}:{msg.offset}",
+        ),
+    )
+
+    message_id = None
+    if MESSAGE_UUID_KEY in headers:
+        message_id = headers[MESSAGE_UUID_KEY]
+    elif isinstance(data, dict) and MESSAGE_UUID_KEY in data:
+        message_id = data[MESSAGE_UUID_KEY]
+
+    if message_id:
+        if is_valid_uuid(message_id):
+            event_uuid = message_id
+        else:
+            # If not a valid UUID, we must warn the user and use
+            # the generated UUID instead. The original UUID is copied to
+            # event.meta.message_id for tracking purposes.
+            event["meta"]["message_id"] = message_id
+            if not _uuid_warning["emitted"]:
+                _uuid_warning["emitted"] = True
+                logger.warning(
+                    "Provided message_uuid is not a valid UUID,"
+                    " using generated UUID. The original value has been"
+                    " stored under event.meta.message_id for tracking.",
+                )
+
+    event["meta"]["uuid"] = event_uuid
+
+
 async def receive_msg(
     queue: asyncio.Queue[Any],
     kafka_consumer: AIOKafkaConsumer,
@@ -402,24 +463,20 @@ async def receive_msg(
     async for msg in kafka_consumer:
         event: dict[str, Any] = {
             "meta": {
-                "uuid": f"{msg.topic}:{msg.partition}:{msg.offset}",
                 "produced_at": get_message_timestamp(msg),
             },
         }
 
         # Process headers
+        headers: dict[str, str] = {}
         try:
-            headers: dict[str, str] = {
-                header[0]: header[1].decode(encoding) for header in msg.headers
-            }
+            headers = {header[0]: header[1].decode(encoding) for header in msg.headers}
             event["meta"]["headers"] = headers
-            if MESSAGE_UUID_KEY in headers:
-                event["meta"]["uuid"] = headers[MESSAGE_UUID_KEY]
-
         except UnicodeError:
             logger.exception("Unicode error while decoding headers")
 
         # Process message body
+        data = None
         try:
             value = msg.value.decode(encoding)
             data = json.loads(value)
@@ -428,17 +485,12 @@ async def receive_msg(
             data = value
         except UnicodeError:
             logger.exception("Unicode error while decoding message body")
-            data = None
+
+        # Process event UUID
+        _process_event_uuid(msg, headers, data, event)
 
         # Add data to the event and put it into the queue
         if data:
-            if (
-                MESSAGE_UUID_KEY not in event["meta"].get("headers", {})
-                and isinstance(data, dict)
-                and MESSAGE_UUID_KEY in data
-            ):
-                event["meta"]["uuid"] = data[MESSAGE_UUID_KEY]
-
             event["body"] = data
             await queue.put(event)
             if eda_feedback_queue:

--- a/tests/unit/event_source/test_kafka.py
+++ b/tests/unit/event_source/test_kafka.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -124,7 +125,9 @@ def test_receive_from_kafka_place_in_queue(
         # Check for the new meta fields: uuid and produced_at
         assert "uuid" in myqueue.queue[0]["meta"]
         assert "produced_at" in myqueue.queue[0]["meta"]
-        assert myqueue.queue[0]["meta"]["uuid"] == "test-topic:0:0"
+        # UUID should be a valid UUID5 generated from topic:partition:offset
+        expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "test-topic:0:0"))
+        assert myqueue.queue[0]["meta"]["uuid"] == expected_uuid
         assert len(myqueue.queue) == TEST_ITEMS_COUNT
 
 
@@ -149,13 +152,14 @@ def test_mixed_topics_and_patterns(
 
 
 def test_message_uuid_in_headers(myqueue: MockQueue) -> None:
-    """Test that message_uuid from headers is used as the event uuid."""
+    """Test that valid message_uuid from headers is used as the event uuid."""
+    valid_uuid = "8472ff2c-6045-4418-8d4e-46f6cffc8557"
 
     class MockConsumerWithUUID(MockConsumer):
         def __aiter__(self) -> AsyncIterator:
             self.async_iterator = AsyncIterator(
                 count=1,
-                headers={"message_uuid": "test-uuid-123", "foo": "bar"},
+                headers={"message_uuid": valid_uuid, "foo": "bar"},
             )
             return self.async_iterator
 
@@ -175,19 +179,20 @@ def test_message_uuid_in_headers(myqueue: MockQueue) -> None:
             ),
         )
         assert len(myqueue.queue) == 1
-        assert myqueue.queue[0]["meta"]["uuid"] == "test-uuid-123"
-        assert myqueue.queue[0]["meta"]["headers"]["message_uuid"] == "test-uuid-123"
+        assert myqueue.queue[0]["meta"]["uuid"] == valid_uuid
+        assert myqueue.queue[0]["meta"]["headers"]["message_uuid"] == valid_uuid
 
 
 def test_message_uuid_in_body(myqueue: MockQueue) -> None:
-    """Test that message_uuid from body overrides the generated uuid."""
+    """Test that valid message_uuid from body overrides the generated uuid."""
+    valid_uuid = "a1b2c3d4-e5f6-4789-abcd-ef0123456789"
 
     class MockConsumerWithBodyUUID(MockConsumer):
         def __aiter__(self) -> AsyncIterator:
             self.async_iterator = AsyncIterator(
                 count=1,
                 headers={"foo": "bar"},
-                body={"message_uuid": "body-uuid-456", "data": "test"},
+                body={"message_uuid": valid_uuid, "data": "test"},
             )
             return self.async_iterator
 
@@ -207,19 +212,21 @@ def test_message_uuid_in_body(myqueue: MockQueue) -> None:
             ),
         )
         assert len(myqueue.queue) == 1
-        assert myqueue.queue[0]["meta"]["uuid"] == "body-uuid-456"
-        assert myqueue.queue[0]["body"]["message_uuid"] == "body-uuid-456"
+        assert myqueue.queue[0]["meta"]["uuid"] == valid_uuid
+        assert myqueue.queue[0]["body"]["message_uuid"] == valid_uuid
 
 
 def test_message_uuid_header_takes_precedence(myqueue: MockQueue) -> None:
     """Test that message_uuid from header takes precedence over body."""
+    header_uuid = "8472ff2c-6045-4418-8d4e-46f6cffc8557"
+    body_uuid = "a1b2c3d4-e5f6-4789-abcd-ef0123456789"
 
     class MockConsumerWithBothUUID(MockConsumer):
         def __aiter__(self) -> AsyncIterator:
             self.async_iterator = AsyncIterator(
                 count=1,
-                headers={"message_uuid": "header-uuid", "foo": "bar"},
-                body={"message_uuid": "body-uuid", "data": "test"},
+                headers={"message_uuid": header_uuid, "foo": "bar"},
+                body={"message_uuid": body_uuid, "data": "test"},
             )
             return self.async_iterator
 
@@ -240,11 +247,11 @@ def test_message_uuid_header_takes_precedence(myqueue: MockQueue) -> None:
         )
         assert len(myqueue.queue) == 1
         # Header uuid should take precedence over body uuid
-        assert myqueue.queue[0]["meta"]["uuid"] == "header-uuid"
+        assert myqueue.queue[0]["meta"]["uuid"] == header_uuid
 
 
 def test_generated_uuid_from_coordinates(myqueue: MockQueue) -> None:
-    """Test that uuid is generated from topic:partition:offset when not provided."""
+    """Test that a valid UUID5 is generated from topic:partition:offset."""
 
     class MockConsumerWithCoordinates(MockConsumer):
         def __aiter__(self) -> AsyncIterator:
@@ -274,7 +281,8 @@ def test_generated_uuid_from_coordinates(myqueue: MockQueue) -> None:
             ),
         )
         assert len(myqueue.queue) == 1
-        assert myqueue.queue[0]["meta"]["uuid"] == "my-topic:5:100"
+        expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "my-topic:5:100"))
+        assert myqueue.queue[0]["meta"]["uuid"] == expected_uuid
 
 
 def test_produced_at_timestamp(myqueue: MockQueue) -> None:
@@ -752,3 +760,41 @@ def test_feedback_queue_timeout(myqueue: MockQueue) -> None:
         assert len(myqueue.queue) == 1
         # Commit should not be called when timeout occurs
         assert commit_count_tracker["count"] == 0
+
+
+def test_invalid_uuid_in_header_falls_back_to_generated(myqueue: MockQueue) -> None:
+    """Test that invalid message_uuid in header falls back to generated UUID."""
+
+    class MockConsumerWithInvalidHeaderUUID(MockConsumer):
+        def __aiter__(self) -> AsyncIterator:
+            self.async_iterator = AsyncIterator(
+                count=1,
+                headers={"message_uuid": "not-a-valid-uuid", "foo": "bar"},
+                body={"data": "test"},
+                topic="my-topic",
+                partition=0,
+                offset=42,
+            )
+            return self.async_iterator
+
+    with patch(
+        "extensions.eda.plugins.event_source.kafka.AIOKafkaConsumer",
+        new=MockConsumerWithInvalidHeaderUUID,
+    ):
+        asyncio.run(
+            kafka_main(
+                myqueue,
+                {
+                    "topic": "eda",
+                    "host": "localhost",
+                    "port": "9092",
+                    "group_id": "test",
+                },
+            ),
+        )
+        assert len(myqueue.queue) == 1
+        # Should use the generated UUID, not the invalid one
+        expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "my-topic:0:42"))
+        assert myqueue.queue[0]["meta"]["uuid"] == expected_uuid
+        # Original value should be preserved in message_id
+        assert myqueue.queue[0]["meta"]["message_id"] == "not-a-valid-uuid"


### PR DESCRIPTION
Currently we perform no UUID validation on the kafka event source plugin, which is causing validation failures in eda-server. This fix implements UUID generation in the event message_uuid is not a valid UUID.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic UUID assignment for Kafka events (UUID5 from topic:partition:offset). A valid UUID in headers overrides body; invalid header UUIDs trigger a one-time warning, are preserved as the original identifier, and the generated UUID is used.

* **Documentation**
  * Clarified UUID assignment rules, precedence, and invalid-UUID fallback behavior.

* **Tests**
  * Added/updated tests for deterministic UUIDs, header/body precedence, and invalid-UUID fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->