### PR TITLE
chore(deps): remove ansible-core and bump requires_ansible to 2.16.0

### DIFF
--- a/.config/requirements-test.in
+++ b/.config/requirements-test.in
@@ -1,4 +1,5 @@
 -r requirements.in
+ansible-core>=2.15
 coverage-enable-subprocess>=1.0 # see https://github.com/nedbat/coveragepy/issues/1341#issuecomment-1228942657
 coverage==6.5.0; python_version < "3.10"  # ansible-core will complain
 coverage==7.3.2; python_version == "3.10"  # ansible-core will complain

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -43,7 +43,7 @@ jobs:
           # python versions, regardless the tox pyXY name.
           other_names: |
             lint:tox -e lint;tox -e ruff
-            docs-sanity:tox -e docs;tox -e py39-sanity-ansible2.15;tox -e py310-sanity-ansible2.16;tox -e py311-sanity-ansible2.17
+            docs-sanity:tox -e docs;tox -e py310-sanity-ansible2.16;tox -e py311-sanity-ansible2.17
             py39:tox -e py39-unit;tox -e py39-integration;tox -e coverage
             py310:tox -e py310-unit; tox -e py310-integration;tox -e coverage
             py311:tox -e py311-unit; tox -e py311-integration;tox -e coverage
@@ -84,7 +84,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # needed by setuptools-scm

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
 # https://access.redhat.com/support/policy/updates/ansible-automation-platform
 # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-requires_ansible: ">=2.15.0" # AAP 2.4 or newer
+requires_ansible: ">=2.16.0" # AAP 2.4 or newer
 action_groups:
   eda:
     - activation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ansible-core>=2.15
 pyyaml>=6.0.1
 aiobotocore
 aiohttp


### PR DESCRIPTION
## Summary

This PR removes the `ansible-core` dependency from `requirements.txt` and bumps `requires_ansible` to `2.16.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minimum Ansible requirement raised to 2.16.0.
  * Removed a direct runtime dependency on ansible-core from runtime requirements.
  * Test dependency file updated to reference ansible-core (minimum 2.15).

* **Tests**
  * CI/test matrix adjusted to run sanity jobs for newer Python/Ansible combinations and remove the older Ansible 2.15 sanity run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->