### PR TITLE
feat(rbac): add role_team_assignment module for AAP 2.5

### DIFF
--- a/.config/manifest.txt
+++ b/.config/manifest.txt
@@ -96,6 +96,7 @@ plugins/modules/event_stream.py
 plugins/modules/event_stream_info.py
 plugins/modules/project.py
 plugins/modules/project_info.py
+plugins/modules/role_team_assignment.py
 plugins/modules/rulebook_activation.py
 plugins/modules/rulebook_activation_copy.py
 plugins/modules/rulebook_activation_info.py

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -22,6 +22,7 @@ action_groups:
     - rulebook_info
     - rulebook_activation
     - rulebook_activation_copy
+    - role_team_assignment
     - rulebook_activation_info
     - user
 plugin_routing:

--- a/plugins/modules/role_team_assignment.py
+++ b/plugins/modules/role_team_assignment.py
@@ -1,0 +1,366 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = r"""
+---
+module: role_team_assignment
+author:
+    - Brandon Whittington (@B-Whitt)
+short_description: Assign a role to a team in EDA Controller
+version_added: "2.13.0"
+description:
+    - This module allows you to create or remove role-based access assignments
+      for teams in EDA Controller.
+    - Assignments grant a team permissions defined by a role definition,
+      optionally scoped to a specific resource (organization, project, etc.).
+    - Assignments are immutable after creation. Delete and re-create to change them.
+    - This module is for AAP 2.5 only. For AAP 2.6+, use
+      ansible.platform.role_team_assignment.
+options:
+    role_definition:
+        description:
+            - The name or numeric ID of the role definition that defines
+              the permissions to grant.
+        required: true
+        type: str
+    team:
+        description:
+            - The name or numeric ID of the team receiving the role.
+            - Mutually exclusive with I(team_ansible_id).
+        required: false
+        type: str
+    team_ansible_id:
+        description:
+            - The Ansible resource UUID of the team.
+            - Alternative to I(team).
+        required: false
+        type: str
+    object_id:
+        description:
+            - The numeric primary key of the resource to scope the assignment to.
+            - Omit for assignments that do not require a specific resource
+              (this depends on the role definition).
+            - Mutually exclusive with I(object_ansible_id).
+        required: false
+        type: int
+    object_ansible_id:
+        description:
+            - The Ansible resource UUID of the resource to scope the assignment to.
+            - Alternative to I(object_id).
+        required: false
+        type: str
+    state:
+        description:
+            - C(present) creates the assignment if it does not exist (idempotent).
+            - C(absent) removes the assignment if it exists (idempotent).
+            - C(exists) checks whether the assignment is present and returns
+              its details. Never modifies anything.
+        choices: ["present", "absent", "exists"]
+        default: "present"
+        type: str
+extends_documentation_fragment: ansible.eda.eda_controller.auths
+notes:
+    - This module is for AAP 2.5 only. For AAP 2.6+, use
+      ansible.platform.role_team_assignment.
+    - Assignments are immutable. They cannot be updated, only created or deleted.
+    - Global roles (content_type=None) cannot be assigned to teams.
+    - Organization Member role cannot be assigned to teams.
+    - The role definition determines which resource type the assignment applies to.
+      The API validates that the object matches the role's content_type.
+"""
+
+
+EXAMPLES = r"""
+- name: Assign Organization Auditor to a team for the Default org
+  ansible.eda.role_team_assignment:
+    role_definition: "Organization Auditor"
+    team: "network-ops"
+    object_id: 1
+    state: present
+
+- name: Assign a role using object_ansible_id for resource scoping
+  ansible.eda.role_team_assignment:
+    role_definition: "Organization Auditor"
+    team: "network-ops"
+    object_ansible_id: "550e8400-e29b-41d4-a716-446655440000"
+    state: present
+
+- name: Remove a team role assignment
+  ansible.eda.role_team_assignment:
+    role_definition: "Organization Auditor"
+    team: "network-ops"
+    object_id: 1
+    state: absent
+
+- name: Check if a team role assignment exists
+  ansible.eda.role_team_assignment:
+    role_definition: "Organization Auditor"
+    team: "network-ops"
+    object_id: 1
+    state: exists
+  register: result
+
+- name: Assign a role using numeric IDs
+  ansible.eda.role_team_assignment:
+    role_definition: "6"
+    team: "1"
+    object_id: 1
+    state: present
+
+- name: Assign a role using team_ansible_id
+  ansible.eda.role_team_assignment:
+    role_definition: "Organization Auditor"
+    team_ansible_id: "550e8400-e29b-41d4-a716-446655440000"
+    object_id: 1
+    state: present
+"""
+
+
+RETURN = r"""
+id:
+    description: ID of the role team assignment.
+    returned: when the assignment exists or was created
+    type: int
+    sample: 42
+role_definition:
+    description: The role definition ID.
+    returned: when state is 'exists' and the assignment is found
+    type: int
+    sample: 6
+team:
+    description: The team ID.
+    returned: when state is 'exists' and the assignment is found
+    type: int
+    sample: 1
+object_id:
+    description: The resource primary key the assignment is scoped to.
+    returned: when state is 'exists' and the assignment is found
+    type: str
+    sample: "1"
+content_type:
+    description: The content type of the scoped resource.
+    returned: when state is 'exists' and the assignment is found
+    type: str
+    sample: "shared.organization"
+object_ansible_id:
+    description: The Ansible resource UUID of the scoped resource.
+    returned: when state is 'exists' and the assignment is found
+    type: str
+    sample: null
+team_ansible_id:
+    description: The Ansible resource UUID of the team.
+    returned: when state is 'exists' and the assignment is found
+    type: str
+    sample: "550e8400-e29b-41d4-a716-446655440000"
+msg:
+    description: Message describing the result.
+    returned: when state is 'exists' and the assignment is not found
+    type: str
+    sample: "Role team assignment not found"
+"""
+
+
+from typing import Any, Optional
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ..module_utils.arguments import AUTH_ARGSPEC
+from ..module_utils.client import Client
+from ..module_utils.common import lookup_resource_id
+from ..module_utils.controller import Controller
+from ..module_utils.errors import EDAError
+
+
+def _resolve_id(
+    module: AnsibleModule,
+    controller: Controller,
+    endpoint: str,
+    value: str,
+    label: str,
+) -> Optional[int]:
+    """Resolve a name-or-ID string to an integer ID."""
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        pass
+
+    resource_id = lookup_resource_id(module, controller, endpoint, value)
+    if resource_id is None:
+        module.fail_json(msg=f"{label} '{value}' not found")
+    return resource_id
+
+
+def _find_existing(
+    controller: Controller,
+    filter_params: dict[str, Any],
+    object_id: Optional[int],
+    object_ansible_id: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Find an existing role_team_assignment matching the filter and object."""
+    params = dict(filter_params, page_size=200)
+    response = controller.get_endpoint("role_team_assignments", data=params)
+
+    if response.status != 200:
+        return None
+
+    json_data = response.json
+    if not isinstance(json_data, dict):
+        return None
+
+    results: list[dict[str, Any]] = json_data.get("results", [])
+    for assignment in results:
+        if object_ansible_id is not None:
+            if str(assignment.get("object_ansible_id")) == str(object_ansible_id):
+                return assignment
+            continue
+
+        existing_obj_id = assignment.get("object_id")
+        if object_id is None and existing_obj_id is None:
+            return assignment
+        if object_id is not None and str(existing_obj_id) == str(object_id):
+            return assignment
+
+    return None
+
+
+def main() -> None:
+    argument_spec = dict(
+        role_definition=dict(required=True, type="str"),
+        team=dict(type="str"),
+        team_ansible_id=dict(type="str"),
+        object_id=dict(type="int"),
+        object_ansible_id=dict(type="str"),
+        state=dict(choices=["present", "absent", "exists"], default="present"),
+    )
+
+    argument_spec.update(AUTH_ARGSPEC)
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ("team", "team_ansible_id"),
+            ("object_id", "object_ansible_id"),
+        ],
+        required_one_of=[
+            ("team", "team_ansible_id"),
+        ],
+        supports_check_mode=True,
+    )
+
+    client = Client(
+        host=module.params.get("controller_host"),
+        username=module.params.get("controller_username"),
+        password=module.params.get("controller_password"),
+        timeout=module.params.get("request_timeout"),
+        validate_certs=module.params.get("validate_certs"),
+        token=module.params.get("controller_token"),
+    )
+
+    controller = Controller(client, module)
+
+    role_definition = module.params.get("role_definition")
+    team = module.params.get("team")
+    team_ansible_id = module.params.get("team_ansible_id")
+    object_id = module.params.get("object_id")
+    object_ansible_id = module.params.get("object_ansible_id")
+    state = module.params.get("state")
+
+    try:
+        role_definition_id = _resolve_id(
+            module,
+            controller,
+            "role_definitions",
+            role_definition,
+            "Role definition",
+        )
+
+        team_id = None
+        if team is not None:
+            team_id = _resolve_id(
+                module,
+                controller,
+                "teams",
+                team,
+                "Team",
+            )
+
+        filter_params: dict[str, Any] = {"role_definition": role_definition_id}
+        if team_id is not None:
+            filter_params["team"] = team_id
+        elif team_ansible_id is not None:
+            filter_params["team_ansible_id"] = team_ansible_id
+        if object_ansible_id is not None:
+            filter_params["object_ansible_id"] = object_ansible_id
+
+        existing = _find_existing(
+            controller,
+            filter_params,
+            object_id,
+            object_ansible_id,
+        )
+
+        if state == "present":
+            if existing:
+                module.exit_json(changed=False, id=existing["id"])
+                return
+
+            if module.check_mode:
+                module.exit_json(changed=True)
+                return
+
+            payload: dict[str, Any] = {"role_definition": role_definition_id}
+            if team_id is not None:
+                payload["team"] = team_id
+            elif team_ansible_id is not None:
+                payload["team_ansible_id"] = team_ansible_id
+            if object_id is not None:
+                payload["object_id"] = object_id
+            elif object_ansible_id is not None:
+                payload["object_ansible_id"] = object_ansible_id
+
+            response = controller.post_endpoint(
+                "role_team_assignments",
+                data=payload,
+            )
+
+            module.exit_json(changed=True, id=response.json["id"])
+
+        elif state == "absent":
+            if not existing:
+                module.exit_json(changed=False)
+                return
+
+            if module.check_mode:
+                module.exit_json(changed=True, id=existing["id"])
+                return
+
+            response = controller.delete_endpoint(
+                f"role_team_assignments/{existing['id']}/",
+            )
+
+            module.exit_json(changed=True, id=existing["id"])
+
+        elif state == "exists":
+            if existing:
+                details = {k: v for k, v in existing.items() if k != "id"}
+                module.exit_json(changed=False, id=existing["id"], **details)
+            else:
+                module.exit_json(
+                    changed=False,
+                    msg="Role team assignment not found",
+                )
+
+    except EDAError as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/role_team_assignment/tasks/main.yml
+++ b/tests/integration/targets/role_team_assignment/tasks/main.yml
@@ -1,0 +1,199 @@
+---
+- name: Role Team Assignment integration tests
+  module_defaults:
+    group/ansible.eda.eda:
+      aap_hostname: "{{ aap_hostname }}"
+      aap_username: "{{ aap_username }}"
+      aap_password: "{{ aap_password }}"
+      aap_validate_certs: "{{ aap_validate_certs }}"
+  block:
+    - name: Generate unique test ID
+      ansible.builtin.set_fact:
+        random_string: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=8') }}"
+
+    - name: Set test variables
+      ansible.builtin.set_fact:
+        test_team_name: "test-rta-{{ random_string }}"
+        test_role_name: "Organization Auditor"
+        test_org_id: 1
+
+    # Detect whether Gateway is available (full AAP) or only EDA standalone.
+    # When ALLOW_LOCAL_RESOURCE_MANAGEMENT=False (AAP with Gateway), teams
+    # must be created via the Gateway API. When True (standalone eda-server
+    # or staging CI), use the EDA API directly.
+    - name: Check if Gateway API is available
+      ansible.builtin.uri:
+        url: "{{ aap_hostname }}/api/gateway/v1/teams/"
+        method: GET
+        user: "{{ aap_username }}"
+        password: "{{ aap_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ aap_validate_certs }}"
+        status_code: [200, 403, 404, 405, 502]
+      register: gateway_check
+      ignore_errors: true
+
+    - name: Set teams API endpoint
+      ansible.builtin.set_fact:
+        use_gateway: >-
+          {{ gateway_check.status == 200 and
+             gateway_check.content_type is defined and
+             'application/json' in gateway_check.content_type }}
+        teams_api_url: >-
+          {{ (gateway_check.status == 200 and
+              gateway_check.content_type is defined and
+              'application/json' in gateway_check.content_type) |
+             ternary(aap_hostname ~ '/api/gateway/v1/teams/',
+                     aap_hostname ~ '/api/eda/v1/teams/') }}
+
+    - name: Create test team
+      ansible.builtin.uri:
+        url: "{{ teams_api_url }}"
+        method: POST
+        user: "{{ aap_username }}"
+        password: "{{ aap_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ aap_validate_certs }}"
+        body_format: json
+        body: >-
+          {{ (use_gateway | bool) |
+             ternary({'name': test_team_name, 'organization': test_org_id},
+                     {'name': test_team_name, 'organization_id': test_org_id}) }}
+        status_code: [201]
+      register: create_team_result
+
+    # -- state=present: create assignment -----------------------------------
+
+    - name: Create role team assignment
+      ansible.eda.role_team_assignment:
+        role_definition: "{{ test_role_name }}"
+        team: "{{ test_team_name }}"
+        object_id: "{{ test_org_id }}"
+        state: present
+      register: create_result
+
+    - name: Assert create changed
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+          - create_result.id is defined
+        fail_msg: "Create should report changed with an id. result={{ create_result }}"
+
+    # -- state=present: idempotency -----------------------------------------
+
+    - name: Create same assignment again (idempotency)
+      ansible.eda.role_team_assignment:
+        role_definition: "{{ test_role_name }}"
+        team: "{{ test_team_name }}"
+        object_id: "{{ test_org_id }}"
+        state: present
+      register: idem_result
+
+    - name: Assert idempotent (no change)
+      ansible.builtin.assert:
+        that:
+          - idem_result is not changed
+          - idem_result.id is defined
+        fail_msg: "Second run should not report changed. result={{ idem_result }}"
+
+    # -- state=exists: check assignment exists ------------------------------
+
+    - name: Check assignment exists
+      ansible.eda.role_team_assignment:
+        role_definition: "{{ test_role_name }}"
+        team: "{{ test_team_name }}"
+        object_id: "{{ test_org_id }}"
+        state: exists
+      register: exists_result
+
+    - name: Assert exists returns details
+      ansible.builtin.assert:
+        that:
+          - exists_result is not changed
+          - exists_result.id is defined
+          - exists_result.content_type == "shared.organization"
+        fail_msg: "state=exists should return assignment details. result={{ exists_result }}"
+
+    # -- state=absent: delete assignment ------------------------------------
+
+    - name: Delete role team assignment
+      ansible.eda.role_team_assignment:
+        role_definition: "{{ test_role_name }}"
+        team: "{{ test_team_name }}"
+        object_id: "{{ test_org_id }}"
+        state: absent
+      register: delete_result
+
+    - name: Assert delete changed
+      ansible.builtin.assert:
+        that:
+          - delete_result is changed
+        fail_msg: "Delete should report changed. result={{ delete_result }}"
+
+    # -- state=absent: idempotency (already gone) ---------------------------
+
+    - name: Delete again (idempotency)
+      ansible.eda.role_team_assignment:
+        role_definition: "{{ test_role_name }}"
+        team: "{{ test_team_name }}"
+        object_id: "{{ test_org_id }}"
+        state: absent
+      register: delete_idem_result
+
+    - name: Assert delete idempotent
+      ansible.builtin.assert:
+        that:
+          - delete_idem_result is not changed
+        fail_msg: "Second delete should not report changed. result={{ delete_idem_result }}"
+
+    # -- state=exists: verify assignment is gone ----------------------------
+
+    - name: Check assignment no longer exists
+      ansible.eda.role_team_assignment:
+        role_definition: "{{ test_role_name }}"
+        team: "{{ test_team_name }}"
+        object_id: "{{ test_org_id }}"
+        state: exists
+      register: gone_result
+
+    - name: Assert not found
+      ansible.builtin.assert:
+        that:
+          - gone_result is not changed
+          - gone_result.msg is defined
+          - "'not found' in gone_result.msg"
+        fail_msg: "Should report not found after deletion. result={{ gone_result }}"
+
+    # -- Error case: non-existent role definition ---------------------------
+
+    - name: Assign with non-existent role definition
+      ansible.eda.role_team_assignment:
+        role_definition: "Nonexistent Role That Does Not Exist"
+        team: "{{ test_team_name }}"
+        object_id: "{{ test_org_id }}"
+        state: present
+      register: bad_role_result
+      ignore_errors: true
+
+    - name: Assert failure on bad role definition
+      ansible.builtin.assert:
+        that:
+          - bad_role_result is failed
+        fail_msg: "Should fail with non-existent role. result={{ bad_role_result }}"
+
+  always:
+    - name: Delete test team
+      ansible.builtin.uri:
+        url: "{{ teams_api_url }}{{ create_team_result.json.id }}/"
+        method: DELETE
+        user: "{{ aap_username }}"
+        password: "{{ aap_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ aap_validate_certs }}"
+        status_code: [204, 404]
+      when:
+        - teams_api_url is defined
+        - create_team_result is defined
+        - create_team_result.json is defined
+        - create_team_result.json.id is defined
+      ignore_errors: true

--- a/tests/unit/plugins/modules/test_role_team_assignment.py
+++ b/tests/unit/plugins/modules/test_role_team_assignment.py
@@ -1,0 +1,495 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from typing import Any, Callable, Optional
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+MODULE_PATH = "ansible_collections.ansible.eda.plugins.modules.role_team_assignment"
+
+
+class _AnsibleExit(Exception):
+    """Simulates module.exit_json / module.fail_json halting execution."""
+
+
+def _make_module(params_override: Optional[dict[str, Any]] = None) -> MagicMock:
+    """Build a mock AnsibleModule with sensible defaults."""
+    params: dict[str, Any] = {
+        "controller_host": "https://eda.example.com",
+        "controller_username": "admin",
+        "controller_password": "password",
+        "controller_token": None,
+        "request_timeout": 10.0,
+        "validate_certs": True,
+        "role_definition": "Organization Auditor",
+        "team": "test-team",
+        "team_ansible_id": None,
+        "object_id": 1,
+        "object_ansible_id": None,
+        "state": "present",
+    }
+    if params_override:
+        params.update(params_override)
+
+    module = MagicMock()
+    module.params = params
+    module.check_mode = False
+    module.exit_json.side_effect = _AnsibleExit
+    module.fail_json.side_effect = _AnsibleExit
+    return module
+
+
+def _make_assignment(
+    assignment_id: int = 1,
+    role_def_id: int = 6,
+    team_id: int = 1,
+    object_id: Optional[str] = "1",
+) -> dict[str, Any]:
+    return {
+        "id": assignment_id,
+        "role_definition": role_def_id,
+        "team": team_id,
+        "object_id": object_id,
+        "content_type": "shared.organization",
+    }
+
+
+def _make_api_list(assignments: list[dict[str, Any]]) -> Mock:
+    """Wrap assignments in a paginated API response."""
+    return Mock(
+        status=200,
+        json={"count": len(assignments), "results": assignments},
+    )
+
+
+def _resolve_response(
+    resource_id: int,
+    name: str,
+    extra: Optional[dict[str, Any]] = None,
+) -> Mock:
+    """Build a paginated GET response for name-based ID resolution."""
+    item: dict[str, Any] = {"id": resource_id, "name": name}
+    if extra:
+        item.update(extra)
+    return Mock(
+        status=200,
+        json={"count": 1, "results": [item]},
+    )
+
+
+def _setup_main(
+    params_override: Optional[dict[str, Any]],
+    get_responses: list[Mock],
+    post_response: Optional[Mock] = None,
+    delete_response: Optional[Mock] = None,
+    check_mode: bool = False,
+) -> tuple[MagicMock, MagicMock]:
+    """Wire up mocks for a main() test and return (module, mock_client)."""
+    module = _make_module(params_override)
+    module.check_mode = check_mode
+
+    mock_client = MagicMock()
+    mock_client.get.side_effect = list(get_responses)
+    if post_response:
+        mock_client.post.return_value = post_response
+    if delete_response:
+        mock_client.delete.return_value = delete_response
+
+    return module, mock_client
+
+
+def _run_main(module: MagicMock, mock_client: MagicMock) -> None:
+    """Run main() with the given module and client mocks."""
+    from ansible_collections.ansible.eda.plugins.modules.role_team_assignment import (  # type: ignore
+        main,
+    )
+
+    with (
+        patch(f"{MODULE_PATH}.AnsibleModule", return_value=module),
+        patch(f"{MODULE_PATH}.Client", return_value=mock_client),
+        pytest.raises(_AnsibleExit),
+    ):
+        main()
+
+
+# ---------------------------------------------------------------------------
+# _find_existing — tests the real function with a mock controller
+# ---------------------------------------------------------------------------
+class TestFindExisting:
+    @staticmethod
+    def _import() -> Callable[..., Any]:
+        from ansible_collections.ansible.eda.plugins.modules.role_team_assignment import (
+            _find_existing,
+        )
+
+        return _find_existing  # type: ignore[no-any-return]
+
+    def test_found_by_object_id(self) -> None:
+        fn = self._import()
+        ctrl = MagicMock()
+        ctrl.get_endpoint.return_value = _make_api_list([_make_assignment()])
+        result = fn(ctrl, {"role_definition": 6, "team": 1}, 1)
+        assert result is not None
+        assert result["id"] == 1
+        ctrl.get_endpoint.assert_called_once_with(
+            "role_team_assignments",
+            data={"role_definition": 6, "team": 1, "page_size": 200},
+        )
+
+    def test_not_found_empty_results(self) -> None:
+        fn = self._import()
+        ctrl = MagicMock()
+        ctrl.get_endpoint.return_value = _make_api_list([])
+        assert fn(ctrl, {"role_definition": 6, "team": 1}, 1) is None
+
+    def test_null_object_id_matches_null(self) -> None:
+        fn = self._import()
+        ctrl = MagicMock()
+        ctrl.get_endpoint.return_value = _make_api_list(
+            [_make_assignment(object_id=None)]
+        )
+        result = fn(ctrl, {"role_definition": 6, "team": 1}, None)
+        assert result is not None
+
+    def test_object_id_mismatch_returns_none(self) -> None:
+        fn = self._import()
+        ctrl = MagicMock()
+        ctrl.get_endpoint.return_value = _make_api_list(
+            [_make_assignment(object_id="99")]
+        )
+        assert fn(ctrl, {"role_definition": 6, "team": 1}, 1) is None
+
+    def test_string_int_comparison(self) -> None:
+        """API returns object_id as '1' (str), user passes 1 (int)."""
+        fn = self._import()
+        ctrl = MagicMock()
+        ctrl.get_endpoint.return_value = _make_api_list(
+            [_make_assignment(object_id="1")]
+        )
+        assert fn(ctrl, {"role_definition": 6, "team": 1}, 1) is not None
+
+    def test_matches_by_object_ansible_id(self) -> None:
+        """When object_ansible_id is provided, match on it instead of object_id."""
+        fn = self._import()
+        ctrl = MagicMock()
+        uuid = "550e8400-e29b-41d4-a716-446655440000"
+        assignment = _make_assignment()
+        assignment["object_ansible_id"] = uuid
+        ctrl.get_endpoint.return_value = _make_api_list([assignment])
+        result = fn(
+            ctrl, {"role_definition": 6, "team": 1}, None, object_ansible_id=uuid
+        )
+        assert result is not None
+        assert result["id"] == 1
+
+    def test_object_ansible_id_mismatch(self) -> None:
+        fn = self._import()
+        ctrl = MagicMock()
+        assignment = _make_assignment()
+        assignment["object_ansible_id"] = "aaaa-bbbb"
+        ctrl.get_endpoint.return_value = _make_api_list([assignment])
+        result = fn(
+            ctrl, {"role_definition": 6, "team": 1}, None, object_ansible_id="cccc-dddd"
+        )
+        assert result is None
+
+    def test_api_error_returns_none(self) -> None:
+        fn = self._import()
+        ctrl = MagicMock()
+        ctrl.get_endpoint.return_value = Mock(status=500)
+        assert fn(ctrl, {"role_definition": 6, "team": 1}, 1) is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_id — tests the real function
+# ---------------------------------------------------------------------------
+class TestResolveId:
+    @staticmethod
+    def _import() -> Callable[..., Any]:
+        from ansible_collections.ansible.eda.plugins.modules.role_team_assignment import (
+            _resolve_id,
+        )
+
+        return _resolve_id  # type: ignore[no-any-return]
+
+    def test_numeric_string_returns_int_without_api_call(self) -> None:
+        fn = self._import()
+        module = MagicMock()
+        ctrl = MagicMock()
+        assert fn(module, ctrl, "role_definitions", "42", "Role") == 42
+
+    def test_name_resolves_via_lookup(self) -> None:
+        fn = self._import()
+        module = MagicMock()
+        ctrl = MagicMock()
+        with patch(f"{MODULE_PATH}.lookup_resource_id", return_value=6) as mock_lookup:
+            result = fn(module, ctrl, "role_definitions", "Org Auditor", "Role")
+        assert result == 6
+        mock_lookup.assert_called_once_with(
+            module,
+            ctrl,
+            "role_definitions",
+            "Org Auditor",
+        )
+
+    def test_name_not_found_calls_fail_json(self) -> None:
+        fn = self._import()
+        module = MagicMock()
+        module.fail_json.side_effect = _AnsibleExit
+        ctrl = MagicMock()
+        with (
+            patch(f"{MODULE_PATH}.lookup_resource_id", return_value=None),
+            pytest.raises(_AnsibleExit),
+        ):
+            fn(module, ctrl, "role_definitions", "nope", "Role definition")
+        assert "not found" in module.fail_json.call_args[1]["msg"]
+        assert "'nope'" in module.fail_json.call_args[1]["msg"]
+
+
+# ---------------------------------------------------------------------------
+# main() tests — only Client and AnsibleModule are patched.
+# _resolve_id and _find_existing run for real against mock HTTP responses.
+# This verifies payloads, filter construction, and endpoint paths.
+# ---------------------------------------------------------------------------
+class TestMainPresent:
+    def test_creates_with_correct_payload(self) -> None:
+        """Verifies the POST payload has role_definition, team, object_id."""
+        module, client = _setup_main(
+            params_override={},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([]),
+            ],
+            post_response=Mock(status=201, json={"id": 42}),
+        )
+        _run_main(module, client)
+
+        module.exit_json.assert_called_once_with(changed=True, id=42)
+        post_call = client.post.call_args
+        payload = (
+            post_call[1].get("data") or post_call[0][1]
+            if len(post_call[0]) > 1
+            else post_call[1]["data"]
+        )
+        assert payload["role_definition"] == 6
+        assert payload["team"] == 1
+        assert payload["object_id"] == 1
+
+    def test_idempotent_when_exists(self) -> None:
+        module, client = _setup_main(
+            params_override={},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([_make_assignment()]),
+            ],
+        )
+        _run_main(module, client)
+
+        module.exit_json.assert_called_once_with(changed=False, id=1)
+        client.post.assert_not_called()
+
+    def test_check_mode_does_not_post(self) -> None:
+        module, client = _setup_main(
+            params_override={},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([]),
+            ],
+            check_mode=True,
+        )
+        _run_main(module, client)
+
+        module.exit_json.assert_called_once_with(changed=True)
+        client.post.assert_not_called()
+
+    def test_team_ansible_id_payload(self) -> None:
+        """Verifies team_ansible_id is sent in payload and filter, not team."""
+        uuid = "550e8400-e29b-41d4-a716-446655440000"
+        module, client = _setup_main(
+            params_override={
+                "team": None,
+                "team_ansible_id": uuid,
+            },
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _make_api_list([]),
+            ],
+            post_response=Mock(status=201, json={"id": 99}),
+        )
+        _run_main(module, client)
+
+        post_data = client.post.call_args[1].get("data", {})
+        assert "team" not in post_data
+        assert post_data["team_ansible_id"] == uuid
+
+        find_call = client.get.call_args_list[-1]
+        filter_data = find_call[1].get("data", {})
+        assert filter_data.get("team_ansible_id") == uuid
+
+    def test_object_ansible_id_payload(self) -> None:
+        """Verifies object_ansible_id is sent instead of object_id."""
+        obj_uuid = "660e8400-e29b-41d4-a716-446655440000"
+        module, client = _setup_main(
+            params_override={
+                "object_id": None,
+                "object_ansible_id": obj_uuid,
+            },
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([]),
+            ],
+            post_response=Mock(status=201, json={"id": 77}),
+        )
+        _run_main(module, client)
+
+        post_data = client.post.call_args[1].get("data", {})
+        assert "object_id" not in post_data
+        assert post_data["object_ansible_id"] == obj_uuid
+
+        # Verify filter used object_ansible_id for the find call
+        find_call = client.get.call_args_list[-1]
+        filter_data = find_call[1].get("data", {})
+        assert filter_data.get("object_ansible_id") == obj_uuid
+
+    def test_post_failure_calls_fail_json(self) -> None:
+        module, client = _setup_main(
+            params_override={},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([]),
+            ],
+            post_response=Mock(
+                status=400,
+                data='{"detail":"bad request"}',
+                json={"detail": "bad request"},
+            ),
+        )
+        _run_main(module, client)
+
+        module.fail_json.assert_called_once()
+        assert "HTTP error" in module.fail_json.call_args[1]["msg"]
+
+
+class TestMainAbsent:
+    def test_deletes_with_correct_endpoint(self) -> None:
+        module, client = _setup_main(
+            params_override={"state": "absent"},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([_make_assignment(assignment_id=55)]),
+            ],
+            delete_response=Mock(status=204),
+        )
+        _run_main(module, client)
+
+        module.exit_json.assert_called_once_with(changed=True, id=55)
+        assert "55" in str(client.delete.call_args)
+
+    def test_idempotent_when_not_exists(self) -> None:
+        module, client = _setup_main(
+            params_override={"state": "absent"},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([]),
+            ],
+        )
+        _run_main(module, client)
+
+        module.exit_json.assert_called_once_with(changed=False)
+        client.delete.assert_not_called()
+
+    def test_check_mode_does_not_delete(self) -> None:
+        module, client = _setup_main(
+            params_override={"state": "absent"},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([_make_assignment()]),
+            ],
+            check_mode=True,
+        )
+        _run_main(module, client)
+
+        module.exit_json.assert_called_once_with(changed=True, id=1)
+        client.delete.assert_not_called()
+
+    def test_delete_failure_calls_fail_json(self) -> None:
+        module, client = _setup_main(
+            params_override={"state": "absent"},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([_make_assignment()]),
+            ],
+            delete_response=Mock(status=500, data="internal error"),
+        )
+        _run_main(module, client)
+
+        module.fail_json.assert_called_once()
+        assert "HTTP error" in module.fail_json.call_args[1]["msg"]
+
+
+class TestMainExists:
+    def test_returns_details_when_found(self) -> None:
+        module, client = _setup_main(
+            params_override={"state": "exists"},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([_make_assignment()]),
+            ],
+        )
+        _run_main(module, client)
+
+        kwargs = module.exit_json.call_args[1]
+        assert kwargs["changed"] is False
+        assert kwargs["id"] == 1
+        assert kwargs["content_type"] == "shared.organization"
+
+    def test_returns_not_found(self) -> None:
+        module, client = _setup_main(
+            params_override={"state": "exists"},
+            get_responses=[
+                _resolve_response(6, "Organization Auditor"),
+                _resolve_response(1, "test-team"),
+                _make_api_list([]),
+            ],
+        )
+        _run_main(module, client)
+
+        kwargs = module.exit_json.call_args[1]
+        assert kwargs["changed"] is False
+        assert "not found" in kwargs["msg"]
+
+
+class TestMainEdaError:
+    def test_eda_error_calls_fail_json(self) -> None:
+        """Verifies the except EDAError handler."""
+        from ansible_collections.ansible.eda.plugins.module_utils.errors import (  # type: ignore
+            EDAHTTPError,
+        )
+
+        module, client = _setup_main(
+            params_override={},
+            get_responses=[],
+        )
+        client.get.side_effect = EDAHTTPError("connection refused")
+
+        _run_main(module, client)
+
+        module.fail_json.assert_called_once()
+        assert "connection refused" in module.fail_json.call_args[1]["msg"]

--- a/tests/unit/plugins/modules/test_role_team_assignment.py
+++ b/tests/unit/plugins/modules/test_role_team_assignment.py
@@ -363,6 +363,10 @@ class TestMainPresent:
         assert filter_data.get("object_ansible_id") == obj_uuid
 
     def test_post_failure_calls_fail_json(self) -> None:
+        from ansible_collections.ansible.eda.plugins.module_utils.errors import (  # type: ignore
+            EDAHTTPError,
+        )
+
         module, client = _setup_main(
             params_override={},
             get_responses=[
@@ -370,12 +374,8 @@ class TestMainPresent:
                 _resolve_response(1, "test-team"),
                 _make_api_list([]),
             ],
-            post_response=Mock(
-                status=400,
-                data='{"detail":"bad request"}',
-                json={"detail": "bad request"},
-            ),
         )
+        client.post.side_effect = EDAHTTPError("HTTP error {'detail': 'bad request'}")
         _run_main(module, client)
 
         module.fail_json.assert_called_once()
@@ -428,6 +428,10 @@ class TestMainAbsent:
         client.delete.assert_not_called()
 
     def test_delete_failure_calls_fail_json(self) -> None:
+        from ansible_collections.ansible.eda.plugins.module_utils.errors import (
+            EDAHTTPError,
+        )
+
         module, client = _setup_main(
             params_override={"state": "absent"},
             get_responses=[
@@ -435,8 +439,8 @@ class TestMainAbsent:
                 _resolve_response(1, "test-team"),
                 _make_api_list([_make_assignment()]),
             ],
-            delete_response=Mock(status=500, data="internal error"),
         )
+        client.delete.side_effect = EDAHTTPError("HTTP error internal error")
         _run_main(module, client)
 
         module.fail_json.assert_called_once()
@@ -479,7 +483,7 @@ class TestMainExists:
 class TestMainEdaError:
     def test_eda_error_calls_fail_json(self) -> None:
         """Verifies the except EDAError handler."""
-        from ansible_collections.ansible.eda.plugins.module_utils.errors import (  # type: ignore
+        from ansible_collections.ansible.eda.plugins.module_utils.errors import (
             EDAHTTPError,
         )
 


### PR DESCRIPTION
## Summary

- Adds `ansible.eda.role_team_assignment` module for creating and removing
  RBAC team role assignments against eda-server's `/api/eda/v1/role_team_assignments/` endpoint
- Supports name-based or numeric ID resolution for `role_definition` and `team`
- Supports `team_ansible_id` and `object_ansible_id` as UUID alternatives
- States: `present` (idempotent create), `absent` (idempotent delete), `exists` (read-only check)
- Follows the `credential_input_source` composite-key pattern (no `name` field)
- This module is intended for use with AAP 2.5 only. For AAP 2.6+, use ansible.platform.role_team_assignment.

## Context

Jira: [AAP-58542](https://redhat.atlassian.net/browse/AAP-58542)

The `ansible.platform` collection has `role_team_assignment` for AAP 2.6/2.7 but it
was never added to stable-2.5. Backporting is not feasible — the 2.5 branch lacks the
action plugin architecture used by 2.7. This module provides equivalent functionality
in `ansible.eda`, talking directly to eda-server.

Prerequisite server-side change (merged): [aap-eda-controller#220](https://github.com/ansible-automation-platform/aap-eda-controller/pull/220)

## Changes

- `plugins/modules/role_team_assignment.py` — new module
- `meta/runtime.yml` — added to `eda` action group
- `tests/unit/plugins/modules/test_role_team_assignment.py` — 22 unit tests (94% coverage)
- `tests/integration/targets/role_team_assignment/tasks/main.yml` — integration test

## Test plan

- [x] All pre-commit hooks pass (ruff, black, mypy, flake8, pylint, isort)
- [x] Unit tests: 22/22 passed via `tox -e unit`
- [x] Integration test: full lifecycle verified against live AAP 2.5 instance
  - Create assignment (changed=true)
  - Idempotency (changed=false)
  - state=exists returns details
  - Delete (changed=true)
  - Delete idempotency (changed=false)
  - state=exists returns "not found"
  - Non-existent role definition fails with descriptive error

Assisted-By: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `role_team_assignment` module to create, delete, and verify role-to-team assignments in EDA Controller with idempotent behavior and check mode support.
  * Enabled the `role_team_assignment` EDA action in the action group configuration.

* **Tests**
  * Added unit tests covering assignment matching, ID resolution, request payloads/filters, and error handling.
  * Added an integration test playbook validating `present`, `absent`, and `exists` behavior, idempotency, and cleanup.

* **Chores**
  * Updated the runtime action group configuration and included the new module in the manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->