### PR TITLE
fix(controller): detect embedded $encrypted$ tokens in field comparison

### DIFF
--- a/plugins/module_utils/controller.py
+++ b/plugins/module_utils/controller.py
@@ -224,6 +224,8 @@ class Controller:
                     return True
         elif obj == Controller.ENCRYPTED_STRING:
             return True
+        elif isinstance(obj, str) and Controller.ENCRYPTED_STRING in obj:
+            return True
         return False
 
     @staticmethod
@@ -242,6 +244,8 @@ class Controller:
             return True  # all sub-fields are either equal or could be equal
         if old_field == Controller.ENCRYPTED_STRING:
             return True
+        if isinstance(old_field, str) and Controller.ENCRYPTED_STRING in old_field:
+            return True
 
         return bool(new_field == old_field)
 
@@ -259,6 +263,12 @@ class Controller:
             old_field = old.get(field, None)
 
             if old_field != new_field:
+                if (
+                    isinstance(old_field, str)
+                    and Controller.ENCRYPTED_STRING in old_field
+                    and old_field != Controller.ENCRYPTED_STRING
+                ):
+                    continue
                 if self.update_secrets or (
                     not self.fields_could_be_same(old_field, new_field)
                 ):

--- a/tests/unit/plugins/module_utils/test_controller.py
+++ b/tests/unit/plugins/module_utils/test_controller.py
@@ -172,6 +172,26 @@ def test_has_encrypted_values() -> None:
     assert Controller.has_encrypted_values({"key": "value"}) is False
 
 
+@pytest.mark.parametrize(
+    "obj, expected",
+    [
+        ("$encrypted$", True),
+        ("http://user:$encrypted$@host:3128", True),
+        ("prefix$encrypted$suffix", True),
+        ("no_secrets_here", False),
+        ("", False),
+        (42, False),
+        (None, False),
+        (["$encrypted$"], True),
+        (["http://user:$encrypted$@host:3128"], True),
+        (["plain"], False),
+        ({"key": "http://user:$encrypted$@host:3128"}, True),
+    ],
+)
+def test_has_encrypted_values_substring(obj: object, expected: bool) -> None:
+    assert Controller.has_encrypted_values(obj) is expected
+
+
 def test_fail_wanted_one(mock_client: Mock, controller: Controller) -> None:
     response = MagicMock()
     response.json.return_value = {"count": 2, "results": [{"id": 1}, {"id": 2}]}
@@ -192,13 +212,67 @@ def test_fields_could_be_same() -> None:
 
 
 @pytest.mark.parametrize(
+    "old_field, new_field, expected",
+    [
+        ("$encrypted$", "anything", True),
+        ("http://user:$encrypted$@host:3128", "http://user:realpass@host:3128", True),
+        ("prefix$encrypted$suffix", "prefixVALUEsuffix", True),
+        ("same_value", "same_value", True),
+        ("different", "values", False),
+        ("no_secret", "other_value", False),
+    ],
+)
+def test_fields_could_be_same_embedded_encrypted(
+    old_field: str, new_field: str, expected: bool
+) -> None:
+    assert Controller.fields_could_be_same(old_field, new_field) is expected
+
+
+@pytest.mark.parametrize(
     "old, new, expected",
     [
         ({"key": "$encrypted$"}, {"key": "value"}, True),
         ({"key": "value"}, {"key": "value"}, False),
+        # Embedded $encrypted$ is skipped even with update_secrets=True
+        (
+            {
+                "proxy": "http://user:$encrypted$@host:3128",
+                "url": "https://example.com",
+            },
+            {"proxy": "http://user:realpass@host:3128", "url": "https://example.com"},
+            False,
+        ),
+        (
+            {
+                "proxy": "http://user:$encrypted$@host:3128",
+                "url": "https://example.com",
+            },
+            {"proxy": "http://user:realpass@host:3128", "url": "https://changed.com"},
+            True,
+        ),
     ],
 )
 def test_objects_could_be_different(
     controller: "Controller", old: dict[str, str], new: dict[str, str], expected: bool
 ) -> None:
     assert controller.objects_could_be_different(old, new) is expected
+
+
+def test_objects_could_be_different_no_update_secrets(
+    mock_client: Mock, mock_module: Mock
+) -> None:
+    """With update_secrets=False (real module default), embedded $encrypted$ is a wildcard."""
+    mock_module.params = {"update_secrets": False}
+    ctrl = Controller(client=mock_client, module=mock_module)
+    old = {
+        "proxy": "http://user:$encrypted$@host:3128",
+        "url": "https://example.com",
+    }
+    new = {"proxy": "http://user:realpass@host:3128", "url": "https://example.com"}
+    assert ctrl.objects_could_be_different(old, new) is False
+
+    new_changed_url = {
+        "proxy": "http://user:realpass@host:3128",
+        "url": "https://changed.com",
+    }
+    assert ctrl.objects_could_be_different(old, new_changed_url) is True


### PR DESCRIPTION
## Summary
- Fixes the root cause of flaky staging CI failures where project delete returns HTTP 409 "Project Sync is running" (AAP-75500)
- The `$encrypted$` detection in `has_encrypted_values()` and `fields_could_be_same()` only matched when the entire field value was `$encrypted$`, missing it when embedded in URLs (e.g., proxy field `http://user:$encrypted$@host:3128`)
- This caused spurious PATCH requests on idempotent module calls, which included unchanged `url` in the payload, triggering an unnecessary server-side project re-sync

## Root Cause
1. Project created with `proxy: "http://eda:testpass@squid:3128"`
2. API returns `proxy: "http://eda:$encrypted$@squid:3128"` (password masked)
3. Idempotent "create again" call compares masked vs unmasked proxy — `$encrypted$` substring not recognized
4. Module sends spurious PATCH with all fields including unchanged `url`
5. Server sees `url` in update_fields → triggers project re-sync → `import_state = PENDING`
6. Subsequent DELETE fails with HTTP 409

## Fix
- Skip fields in `objects_could_be_different()` where `$encrypted$` is embedded as a substring (not the whole value), preventing the false-positive diff
- Extend `has_encrypted_values()` and `fields_could_be_same()` to detect `$encrypted$` as a substring within string values
- Preserves existing `update_secrets=True` behavior for fully-encrypted fields (`$encrypted$` as the entire value)

## Verified
- **Live instance**: idempotent call with proxy now reports `changed: false` and `import_state` stays `completed`
- **CI log comparison**: confirmed main branch failures (PR #554, scheduled runs) show `import_state` regressing after idempotent calls; PR #542's wait loop absorbs the race but doesn't fix the root cause
- **Unit tests**: 262 passed, 0 failed, 0 regressions

## Test plan
- [x] Unit tests for `has_encrypted_values()` with embedded `$encrypted$`
- [x] Unit tests for `fields_could_be_same()` with embedded `$encrypted$`
- [x] Unit tests for `objects_could_be_different()` with proxy-like fields (both `update_secrets=True` and `False`)
- [x] Tox unit tests pass (262 passed)
- [x] Live instance validation against AAP 2.7
- [ ] Staging CI passes (pending merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of encrypted values when the special marker appears inside a string, not just as the entire value.
  * Updated comparison behavior so records with embedded encrypted placeholders are handled more consistently.
  * Reduced false differences when comparing objects that include partially masked secret values.

* **Tests**
  * Expanded unit coverage for encrypted-value detection and object comparison across strings, lists, dictionaries, and mixed secret formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->