### PR TITLE
fix(lint): use YAML-standard truthy values in module examples

### DIFF
--- a/plugins/modules/project.py
+++ b/plugins/modules/project.py
@@ -119,7 +119,7 @@ EXAMPLES = r"""
     scm_branch: "devel"
     organization_name: Default
     state: present
-    update_revision_on_launch: True
+    update_revision_on_launch: true
     scm_update_cache_timeout: 3600
 
 - name: Delete the project

--- a/plugins/modules/rulebook_activation.py
+++ b/plugins/modules/rulebook_activation.py
@@ -191,7 +191,7 @@ EXAMPLES = r"""
     rulebook_name: "hello_controller.yml"
     decision_environment_name: "Example Decision Environment"
     state: disabled
-    restart_on_project_update: False
+    restart_on_project_update: false
 
 - name: Create a rulebook activation with event_streams option
   ansible.eda.rulebook_activation:
@@ -205,7 +205,7 @@ EXAMPLES = r"""
     event_streams:
       - event_stream: "Example Event Stream"
         source_name: "Sample source"
-    restart_on_project_update: False
+    restart_on_project_update: false
 
 - name: Rename a rulebook activation
   ansible.eda.rulebook_activation:
@@ -215,7 +215,7 @@ EXAMPLES = r"""
     rulebook_name: "hello_controller.yml"
     decision_environment_name: "Example Decision Environment"
     organization_name: "Default"
-    restart_on_project_update: False
+    restart_on_project_update: false
 
 - name: Update a rulebook activation
   ansible.eda.rulebook_activation:
@@ -236,33 +236,33 @@ EXAMPLES = r"""
     rulebook_name: "hello_controller.yml"
     decision_environment_name: "Example Decision Environment"
     organization_name: "Default"
-    restart_on_project_update: True
+    restart_on_project_update: true
 
 - name: Enable a rulebook activation
   ansible.eda.rulebook_activation:
     name: "Example Rulebook Activation"
     state: enabled
-    restart_on_project_update: False
+    restart_on_project_update: false
 
 - name: Disable a rulebook activation
   ansible.eda.rulebook_activation:
     name: "Example Rulebook Activation"
     new_name: "Example Rulebook Activation New Name"
     state: disabled
-    restart_on_project_update: False
+    restart_on_project_update: false
 
 - name: Restart activation
   ansible.eda.rulebook_activation:
     name: "Example Rulebook Activation - Restart"
     organization_name: "Default"
     restart: true
-    restart_on_project_update: False
+    restart_on_project_update: false
 
 - name: Delete a rulebook activation
   ansible.eda.rulebook_activation:
     name: "Example Rulebook Activation"
     state: absent
-    restart_on_project_update: False
+    restart_on_project_update: false
 """
 
 


### PR DESCRIPTION
## Summary

- Fixes `yaml[truthy]` ansible-lint failures in `plugins/modules/project.py` and `plugins/modules/rulebook_activation.py` seen during Ansible Certification review on Automation Hub.
- Replaces Python-style `True`/`False` with YAML-standard `true`/`false` in `EXAMPLES` docstrings.
- This fixes the non-EDA specific linting issues reported in #541.

## Verification

Verified the fixes locally using:

```shell
uvx --with 'ansible-core==2.16.0' 'ansible-lint==24.12.2' plugins/modules/project.py plugins/modules/rulebook_activation.py
```

Result: `Passed: 0 failure(s), 0 warning(s) on 4 files.`

## Test plan

- [x] Run `ansible-lint` against the two modified files and confirm 0 failures

Related: #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example playbooks and usage snippets to use consistent lowercase YAML boolean values.
  * Clarified example behavior for rulebook activation when a project is updated, with matching `true`/`false` values across scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->